### PR TITLE
Fix crash when there are no pods matching the regex

### DIFF
--- a/cli/cmd/tapRunner.go
+++ b/cli/cmd/tapRunner.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/up9inc/mizu/shared"
 	"os"
 	"os/signal"
 	"regexp"
 	"syscall"
 	"time"
+
+	"github.com/up9inc/mizu/shared"
 
 	core "k8s.io/api/core/v1"
 

--- a/cli/cmd/tapRunner.go
+++ b/cli/cmd/tapRunner.go
@@ -46,6 +46,22 @@ func RunMizuTap(podRegexQuery *regexp.Regexp, tappingOptions *MizuTapOptions) {
 		currentlyTappedPods = matchingPods
 	}
 
+	var namespacesStr string
+	if targetNamespace != "" {
+		namespacesStr = fmt.Sprintf("namespace \"%s\"", targetNamespace)
+	} else {
+		namespacesStr = "all namespaces"
+	}
+	fmt.Printf("Tapping pods in %s\n", namespacesStr)
+
+	if len(currentlyTappedPods) == 0 {
+		var suggestionStr string
+		if targetNamespace != "" {
+			suggestionStr = "\nSelect a different namespace with -n or tap all namespaces with -A"
+		}
+		fmt.Printf("Did not find any pods matching the regex argument%s\n\n", suggestionStr)
+	}
+
 	nodeToTappedPodIPMap, err := getNodeHostToTappedPodIpsMap(currentlyTappedPods)
 	if err != nil {
 		return

--- a/cli/cmd/tapRunner.go
+++ b/cli/cmd/tapRunner.go
@@ -59,7 +59,7 @@ func RunMizuTap(podRegexQuery *regexp.Regexp, tappingOptions *MizuTapOptions) {
 		if targetNamespace != mizu.K8sAllNamespaces {
 			suggestionStr = "\nSelect a different namespace with -n or tap all namespaces with -A"
 		}
-		fmt.Printf("Did not find any pods matching the regex argument%s\n\n", suggestionStr)
+		fmt.Printf("Did not find any pods matching the regex argument%s\n", suggestionStr)
 	}
 
 	nodeToTappedPodIPMap, err := getNodeHostToTappedPodIpsMap(currentlyTappedPods)

--- a/cli/cmd/tapRunner.go
+++ b/cli/cmd/tapRunner.go
@@ -47,7 +47,7 @@ func RunMizuTap(podRegexQuery *regexp.Regexp, tappingOptions *MizuTapOptions) {
 	}
 
 	var namespacesStr string
-	if targetNamespace != "" {
+	if targetNamespace != mizu.K8sAllNamespaces {
 		namespacesStr = fmt.Sprintf("namespace \"%s\"", targetNamespace)
 	} else {
 		namespacesStr = "all namespaces"
@@ -56,7 +56,7 @@ func RunMizuTap(podRegexQuery *regexp.Regexp, tappingOptions *MizuTapOptions) {
 
 	if len(currentlyTappedPods) == 0 {
 		var suggestionStr string
-		if targetNamespace != "" {
+		if targetNamespace != mizu.K8sAllNamespaces {
 			suggestionStr = "\nSelect a different namespace with -n or tap all namespaces with -A"
 		}
 		fmt.Printf("Did not find any pods matching the regex argument%s\n\n", suggestionStr)

--- a/cli/cmd/tapRunner.go
+++ b/cli/cmd/tapRunner.go
@@ -68,7 +68,7 @@ func createMizuResources(ctx context.Context, kubernetesProvider *kubernetes.Pro
 		return err
 	}
 
-	if err := createMizuTappers(ctx, kubernetesProvider, nodeToTappedPodIPMap, tappingOptions); err != nil {
+	if err := updateMizuTappers(ctx, kubernetesProvider, nodeToTappedPodIPMap, tappingOptions); err != nil {
 		return err
 	}
 
@@ -112,7 +112,7 @@ func getMizuApiFilteringOptions(tappingOptions *MizuTapOptions) (*shared.Traffic
 	return &shared.TrafficFilteringOptions{PlainTextMaskingRegexes: compiledRegexSlice}, nil
 }
 
-func createMizuTappers(ctx context.Context, kubernetesProvider *kubernetes.Provider, nodeToTappedPodIPMap map[string][]string, tappingOptions *MizuTapOptions) error {
+func updateMizuTappers(ctx context.Context, kubernetesProvider *kubernetes.Provider, nodeToTappedPodIPMap map[string][]string, tappingOptions *MizuTapOptions) error {
 	if len(nodeToTappedPodIPMap) > 0 {
 		if err := kubernetesProvider.ApplyMizuTapperDaemonSet(
 			ctx,
@@ -172,7 +172,7 @@ func watchPodsForTapping(ctx context.Context, kubernetesProvider *kubernetes.Pro
 			cancel()
 		}
 
-		if err := createMizuTappers(ctx, kubernetesProvider, nodeToTappedPodIPMap, tappingOptions); err != nil {
+		if err := updateMizuTappers(ctx, kubernetesProvider, nodeToTappedPodIPMap, tappingOptions); err != nil {
 			fmt.Printf("Error updating daemonset: %s (%v,%+v)\n", err, err, err)
 			cancel()
 		}

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -217,7 +217,7 @@ func (provider *Provider) RemovePod(ctx context.Context, namespace string, podNa
 	if isApplied, err := provider.CheckPodExists(ctx, namespace, daemonSetName);
 	err != nil {
 		return err
-	} else if isApplied {
+	} else if !isApplied {
 		return nil
 	}
 
@@ -228,7 +228,7 @@ func (provider *Provider) RemoveService(ctx context.Context, namespace string, s
 	if isApplied, err := provider.CheckServiceExists(ctx, namespace, daemonSetName);
 	err != nil {
 		return err
-	} else if isApplied {
+	} else if !isApplied {
 		return nil
 	}
 
@@ -239,7 +239,7 @@ func (provider *Provider) RemoveDaemonSet(ctx context.Context, namespace string,
 	if isApplied, err := provider.CheckDaemonSetExists(ctx, namespace, daemonSetName);
 	err != nil {
 		return err
-	} else if isApplied {
+	} else if !isApplied {
 		return nil
 	}
 

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -226,6 +226,10 @@ func (provider *Provider) RemoveDaemonSet(ctx context.Context, namespace string,
 }
 
 func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespace string, daemonSetName string, podImage string, tapperPodName string, aggregatorPodIp string, nodeToTappedPodIPMap map[string][]string, linkServiceAccount bool, direction string) error {
+	if len(nodeToTappedPodIPMap) == 0 {
+		return fmt.Errorf("Daemon set %s must tap at least 1 pod", daemonSetName)
+	}
+
 	nodeToTappedPodIPMapJsonStr, err := json.Marshal(nodeToTappedPodIPMap)
 	if err != nil {
 		return err

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -214,7 +214,7 @@ func (provider *Provider) CreateMizuRBAC(ctx context.Context, namespace string, 
 }
 
 func (provider *Provider) RemovePod(ctx context.Context, namespace string, podName string) error {
-	if isFound, err := provider.CheckPodExists(ctx, namespace, daemonSetName);
+	if isFound, err := provider.CheckPodExists(ctx, namespace, podName);
 	err != nil {
 		return err
 	} else if !isFound {
@@ -225,7 +225,7 @@ func (provider *Provider) RemovePod(ctx context.Context, namespace string, podNa
 }
 
 func (provider *Provider) RemoveService(ctx context.Context, namespace string, serviceName string) error {
-	if isFound, err := provider.CheckServiceExists(ctx, namespace, daemonSetName);
+	if isFound, err := provider.CheckServiceExists(ctx, namespace, serviceName);
 	err != nil {
 		return err
 	} else if !isFound {
@@ -263,7 +263,7 @@ func (provider *Provider) CheckPodExists(ctx context.Context, namespace string, 
 	return false, nil
 }
 
-func (provider *Provider) CheckServiceSetExists(ctx context.Context, namespace string, name string) (bool, error) {
+func (provider *Provider) CheckServiceExists(ctx context.Context, namespace string, name string) (bool, error) {
 	listOptions := metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
 		Limit: 1,

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -102,7 +102,6 @@ func (provider *Provider) CreateMizuAggregatorPod(ctx context.Context, namespace
 			},
 			DNSPolicy:                     core.DNSClusterFirstWithHostNet,
 			TerminationGracePeriodSeconds: new(int64),
-			// Affinity: TODO: define node selector for all relevant nodes for this mizu instance
 		},
 	}
 	//define the service account only when it exists to prevent pod crash

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -214,10 +214,10 @@ func (provider *Provider) CreateMizuRBAC(ctx context.Context, namespace string, 
 }
 
 func (provider *Provider) RemovePod(ctx context.Context, namespace string, podName string) error {
-	if isApplied, err := provider.CheckPodExists(ctx, namespace, daemonSetName);
+	if isFound, err := provider.CheckPodExists(ctx, namespace, daemonSetName);
 	err != nil {
 		return err
-	} else if !isApplied {
+	} else if !isFound {
 		return nil
 	}
 
@@ -225,10 +225,10 @@ func (provider *Provider) RemovePod(ctx context.Context, namespace string, podNa
 }
 
 func (provider *Provider) RemoveService(ctx context.Context, namespace string, serviceName string) error {
-	if isApplied, err := provider.CheckServiceExists(ctx, namespace, daemonSetName);
+	if isFound, err := provider.CheckServiceExists(ctx, namespace, daemonSetName);
 	err != nil {
 		return err
-	} else if !isApplied {
+	} else if !isFound {
 		return nil
 	}
 
@@ -236,10 +236,10 @@ func (provider *Provider) RemoveService(ctx context.Context, namespace string, s
 }
 
 func (provider *Provider) RemoveDaemonSet(ctx context.Context, namespace string, daemonSetName string) error {
-	if isApplied, err := provider.CheckDaemonSetExists(ctx, namespace, daemonSetName);
+	if isFound, err := provider.CheckDaemonSetExists(ctx, namespace, daemonSetName);
 	err != nil {
 		return err
-	} else if !isApplied {
+	} else if !isFound {
 		return nil
 	}
 

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -222,7 +222,7 @@ func (provider *Provider) RemoveService(ctx context.Context, namespace string, s
 }
 
 func (provider *Provider) RemoveDaemonSet(ctx context.Context, namespace string, daemonSetName string) error {
-	if isApplied, err := provider.IsDaemonSetApplied(ctx, namespace, daemonSetName);
+	if isApplied, err := provider.CheckDaemonSetExists(ctx, namespace, daemonSetName);
 	err != nil {
 		return err
 	} else if isApplied {
@@ -232,7 +232,7 @@ func (provider *Provider) RemoveDaemonSet(ctx context.Context, namespace string,
 	return provider.clientSet.AppsV1().DaemonSets(namespace).Delete(ctx, daemonSetName, metav1.DeleteOptions{})
 }
 
-func (provider *Provider) IsDaemonSetApplied(ctx context.Context, namespace string, daemonSetName string) (bool, error) {
+func (provider *Provider) CheckDaemonSetExists(ctx context.Context, namespace string, daemonSetName string) (bool, error) {
 	listOptions := metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", daemonSetName),
 		Limit: 1,


### PR DESCRIPTION
1. CLI will not crash if there are no pods matching the regex. Instead it will print a warning and continue to watch the pods.
2. If the number of tapped pods decreases to 0 (at a later stage), CLI will delete mizu-tapper daemonset.
3. Attempting to delete resources that are not installed will not cause an error.