### PR TITLE
TRA-3410 Resource limits

### DIFF
--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -377,7 +377,7 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	if err != nil {
 		return errors.New("invalid cpu request for tapper container")
 	}
-	memRequests, err := resource.ParseQuantity("100Mi")
+	memRequests, err := resource.ParseQuantity("50Mi")
 	if err != nil {
 		return errors.New("invalid memory request for tapper container")
 	}

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -77,14 +77,6 @@ func (provider *Provider) CreateMizuAggregatorPod(ctx context.Context, namespace
 		return nil, err
 	}
 
-	cpuRequests, err := resource.ParseQuantity("50m")
-	if err != nil {
-		return nil, errors.New("invalid cpu request for aggregator container")
-	}
-	memRequests, err := resource.ParseQuantity("50Mi")
-	if err != nil {
-		return nil, errors.New("invalid memory request for aggregator container")
-	}
 	cpuLimit, err := resource.ParseQuantity("750")
 	if err != nil {
 		return nil, errors.New("invalid cpu limit for aggregator container")
@@ -92,6 +84,14 @@ func (provider *Provider) CreateMizuAggregatorPod(ctx context.Context, namespace
 	memLimit, err := resource.ParseQuantity("512Mi")
 	if err != nil {
 		return nil, errors.New("invalid memory limit for aggregator container")
+	}
+	cpuRequests, err := resource.ParseQuantity("50m")
+	if err != nil {
+		return nil, errors.New("invalid cpu request for aggregator container")
+	}
+	memRequests, err := resource.ParseQuantity("50Mi")
+	if err != nil {
+		return nil, errors.New("invalid memory request for aggregator container")
 	}
 
 	pod := &core.Pod{
@@ -118,13 +118,13 @@ func (provider *Provider) CreateMizuAggregatorPod(ctx context.Context, namespace
 						},
 					},
 					Resources: core.ResourceRequirements{
-						Requests: core.ResourceList{
-							"cpu": cpuRequests,
-							"memory": memRequests,
-						},
 						Limits: core.ResourceList{
 							"cpu": cpuLimit,
 							"memory": memLimit,
+						},
+						Requests: core.ResourceList{
+							"cpu": cpuRequests,
+							"memory": memRequests,
 						},
 					},
 				},
@@ -365,14 +365,6 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 			),
 		),
 	)
-	cpuRequests, err := resource.ParseQuantity("50m")
-	if err != nil {
-		return errors.New("invalid cpu request for tapper container")
-	}
-	memRequests, err := resource.ParseQuantity("100Mi")
-	if err != nil {
-		return errors.New("invalid memory request for tapper container")
-	}
 	cpuLimit, err := resource.ParseQuantity("500m")
 	if err != nil {
 		return errors.New("invalid cpu limit for tapper container")
@@ -381,13 +373,21 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	if err != nil {
 		return errors.New("invalid memory limit for tapper container")
 	}
-	agentResourceRequests := core.ResourceList{
-		"cpu": cpuRequests,
-		"memory": memRequests,
+	cpuRequests, err := resource.ParseQuantity("50m")
+	if err != nil {
+		return errors.New("invalid cpu request for tapper container")
+	}
+	memRequests, err := resource.ParseQuantity("100Mi")
+	if err != nil {
+		return errors.New("invalid memory request for tapper container")
 	}
 	agentResourceLimits := core.ResourceList{
 		"cpu": cpuLimit,
 		"memory": memLimit,
+	}
+	agentResourceRequests := core.ResourceList{
+		"cpu": cpuRequests,
+		"memory": memRequests,
 	}
 	agentResources := applyconfcore.ResourceRequirements().WithRequests(agentResourceRequests).WithLimits(agentResourceLimits)
 	agentContainer.WithResources(agentResources)

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -77,19 +77,19 @@ func (provider *Provider) CreateMizuAggregatorPod(ctx context.Context, namespace
 		return nil, err
 	}
 
-	cpuRequests, err := resource.ParseQuantity("200m")
+	cpuRequests, err := resource.ParseQuantity("500m")
 	if err != nil {
 		return nil, errors.New("invalid cpu request for aggregator container")
 	}
-	memRequests, err := resource.ParseQuantity("200Mi")
+	memRequests, err := resource.ParseQuantity("1024Mi")
 	if err != nil {
 		return nil, errors.New("invalid memory request for aggregator container")
 	}
-	cpuLimit, err := resource.ParseQuantity("1000m")
+	cpuLimit, err := resource.ParseQuantity("500m")
 	if err != nil {
 		return nil, errors.New("invalid cpu limit for aggregator container")
 	}
-	memLimit, err := resource.ParseQuantity("500Mi")
+	memLimit, err := resource.ParseQuantity("1024Mi")
 	if err != nil {
 		return nil, errors.New("invalid memory limit for aggregator container")
 	}
@@ -365,19 +365,19 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 			),
 		),
 	)
-	cpuRequests, err := resource.ParseQuantity("200m")
+	cpuRequests, err := resource.ParseQuantity("750m")
 	if err != nil {
 		return errors.New("invalid cpu request for tapper container")
 	}
-	memRequests, err := resource.ParseQuantity("200Mi")
+	memRequests, err := resource.ParseQuantity("512Mi")
 	if err != nil {
 		return errors.New("invalid memory request for tapper container")
 	}
-	cpuLimit, err := resource.ParseQuantity("1000m")
+	cpuLimit, err := resource.ParseQuantity("750m")
 	if err != nil {
 		return errors.New("invalid cpu limit for tapper container")
 	}
-	memLimit, err := resource.ParseQuantity("500Mi")
+	memLimit, err := resource.ParseQuantity("512Mi")
 	if err != nil {
 		return errors.New("invalid memory limit for tapper container")
 	}

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -85,11 +85,11 @@ func (provider *Provider) CreateMizuAggregatorPod(ctx context.Context, namespace
 	if err != nil {
 		return nil, errors.New("invalid memory request for aggregator container")
 	}
-	cpuLimit, err := resource.ParseQuantity("500m")
+	cpuLimit, err := resource.ParseQuantity("750")
 	if err != nil {
 		return nil, errors.New("invalid cpu limit for aggregator container")
 	}
-	memLimit, err := resource.ParseQuantity("1024Mi")
+	memLimit, err := resource.ParseQuantity("512Mi")
 	if err != nil {
 		return nil, errors.New("invalid memory limit for aggregator container")
 	}
@@ -373,11 +373,11 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	if err != nil {
 		return errors.New("invalid memory request for tapper container")
 	}
-	cpuLimit, err := resource.ParseQuantity("750m")
+	cpuLimit, err := resource.ParseQuantity("500m")
 	if err != nil {
 		return errors.New("invalid cpu limit for tapper container")
 	}
-	memLimit, err := resource.ParseQuantity("512Mi")
+	memLimit, err := resource.ParseQuantity("1Gi")
 	if err != nil {
 		return errors.New("invalid memory limit for tapper container")
 	}

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -77,11 +77,11 @@ func (provider *Provider) CreateMizuAggregatorPod(ctx context.Context, namespace
 		return nil, err
 	}
 
-	cpuRequests, err := resource.ParseQuantity("500m")
+	cpuRequests, err := resource.ParseQuantity("50m")
 	if err != nil {
 		return nil, errors.New("invalid cpu request for aggregator container")
 	}
-	memRequests, err := resource.ParseQuantity("1024Mi")
+	memRequests, err := resource.ParseQuantity("50Mi")
 	if err != nil {
 		return nil, errors.New("invalid memory request for aggregator container")
 	}
@@ -365,11 +365,11 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 			),
 		),
 	)
-	cpuRequests, err := resource.ParseQuantity("750m")
+	cpuRequests, err := resource.ParseQuantity("50m")
 	if err != nil {
 		return errors.New("invalid cpu request for tapper container")
 	}
-	memRequests, err := resource.ParseQuantity("512Mi")
+	memRequests, err := resource.ParseQuantity("100Mi")
 	if err != nil {
 		return errors.New("invalid memory request for tapper container")
 	}


### PR DESCRIPTION
Set resource requests and limits.

Aggregator (based on sock-shop during load test):

- limit cpu: 750m

- limit memory: 512Mi

- request cpu: 50m

- request memory: 50Mi

Tapper (limits are identical to passive-tapper’s limit in a regular up9 install):

- limit cpu: 500m

- limit memory: 1Gi

- request cpu: 50m

- request memory: 50Mi

Set low request values in order to ensure that Mizu starts successfully.