### PR TITLE
Missing request body

### DIFF
--- a/tap/har_writer.go
+++ b/tap/har_writer.go
@@ -54,6 +54,11 @@ func NewEntry(request *http.Request, requestTime time.Time, response *http.Respo
 		return nil, errors.New("Failed converting request to HAR")
 	}
 
+	// For requests with multipart/form-data or application/x-www-form-urlencoded Content-Type,
+	// martian/har will parse the request body and place the parameters in harRequest.PostData.Params
+	// instead of harRequest.PostData.Text (as the HAR spec requires it).
+	// Mizu currently only looks at PostData.Text. Therefore, instead of letting martian/har set the content of
+	// PostData, always copy the request body to PostData.Text.
 	if (request.ContentLength > 0) {
 		reqBody, err := ioutil.ReadAll(request.Body)
 		if err != nil {


### PR DESCRIPTION
For requests with multipart/form-data or application/x-www-form-urlencoded media-types, martian/har will parse the request body and place the parameters in harRequest.PostData.Params instead of harRequest.PostData.Text (as the HAR spec requires it). Mizu currently only looks at PostData.Text. Therefore, instead of letting martian/har set the content of PostData, always copy the request body to PostData.Text.