### PR TITLE
Added a default SEM_VER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ help: ## This help.
 TS_SUFFIX="$(shell date '+%s')"
 GIT_BRANCH="$(shell git branch | grep \* | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]' | tr '/' '_')"
 BUCKET_PATH=static.up9.io/mizu/$(GIT_BRANCH)
+export SEM_VER?=0.0.0
 
 ui: ## build UI
 	@(cd ui; npm i ; npm run build; )

--- a/build-push-featurebranch.sh
+++ b/build-push-featurebranch.sh
@@ -15,14 +15,18 @@ then
   exit 1
 fi
 
-for DOCKER_TAG in ${DOCKER_TAGGED_BUILDS[@]}
+DOCKER_TAG_FIRST="${DOCKER_TAGGED_BUILDS[0]}"
+echo "building $DOCKER_TAG_FIRST"
+docker build -t "$DOCKER_TAG_FIRST" --build-arg SEM_VER=${SEM_VER} --build-arg BUILD_TIMESTAMP=${BUILD_TIMESTAMP} --build-arg GIT_BRANCH=${GIT_BRANCH} --build-arg COMMIT_HASH=${COMMIT_HASH} .
+
+for DOCKER_TAG in "${DOCKER_TAGGED_BUILDS[@]:1}"
 do
-        echo "building $DOCKER_TAG"
-        docker build -t "$DOCKER_TAG" --build-arg SEM_VER=${SEM_VER} --build-arg BUILD_TIMESTAMP=${BUILD_TIMESTAMP} --build-arg GIT_BRANCH=${GIT_BRANCH} --build-arg COMMIT_HASH=${COMMIT_HASH} .
+        echo "tagging as $DOCKER_TAG"
+        docker tag "$DOCKER_TAG_FIRST" "$DOCKER_TAG"
 done
 
-for DOCKER_TAG in ${DOCKER_TAGGED_BUILDS[@]}
+for DOCKER_TAG in "${DOCKER_TAGGED_BUILDS[@]}"
 do
-        echo pushing to "$REPOSITORY"
+        echo pushing "$DOCKER_TAG"
         docker push "$DOCKER_TAG"
 done

--- a/build-push-featurebranch.sh
+++ b/build-push-featurebranch.sh
@@ -5,6 +5,7 @@ SERVER_NAME=mizu
 GCP_PROJECT=up9-docker-hub
 REPOSITORY=gcr.io/$GCP_PROJECT
 GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]')
+SEM_VER=${SEM_VER=0.0.0}
 DOCKER_TAGGED_BUILD=$REPOSITORY/$SERVER_NAME/$GIT_BRANCH:latest
 
 if [ "$GIT_BRANCH" = 'develop' -o "$GIT_BRANCH" = 'master' -o "$GIT_BRANCH" = 'main' ]

--- a/build-push-featurebranch.sh
+++ b/build-push-featurebranch.sh
@@ -15,15 +15,9 @@ then
   exit 1
 fi
 
-DOCKER_TAG_FIRST="${DOCKER_TAGGED_BUILDS[0]}"
-echo "building $DOCKER_TAG_FIRST"
-docker build -t "$DOCKER_TAG_FIRST" --build-arg SEM_VER=${SEM_VER} --build-arg BUILD_TIMESTAMP=${BUILD_TIMESTAMP} --build-arg GIT_BRANCH=${GIT_BRANCH} --build-arg COMMIT_HASH=${COMMIT_HASH} .
-
-for DOCKER_TAG in "${DOCKER_TAGGED_BUILDS[@]:1}"
-do
-        echo "tagging as $DOCKER_TAG"
-        docker tag "$DOCKER_TAG_FIRST" "$DOCKER_TAG"
-done
+echo "building ${DOCKER_TAGGED_BUILDS[@]}"
+DOCKER_TAGS_ARGS=$(echo ${DOCKER_TAGGED_BUILDS[@]/#/-t }) # "-t FIRST_TAG -t SECOND_TAG ..."
+docker build $DOCKER_TAGS_ARGS --build-arg SEM_VER=${SEM_VER} --build-arg BUILD_TIMESTAMP=${BUILD_TIMESTAMP} --build-arg GIT_BRANCH=${GIT_BRANCH} --build-arg COMMIT_HASH=${COMMIT_HASH} .
 
 for DOCKER_TAG in "${DOCKER_TAGGED_BUILDS[@]}"
 do

--- a/build-push-featurebranch.sh
+++ b/build-push-featurebranch.sh
@@ -6,7 +6,8 @@ GCP_PROJECT=up9-docker-hub
 REPOSITORY=gcr.io/$GCP_PROJECT
 GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]')
 SEM_VER=${SEM_VER=0.0.0}
-DOCKER_TAGGED_BUILD=$REPOSITORY/$SERVER_NAME/$GIT_BRANCH:latest
+DOCKER_REPO=$REPOSITORY/$SERVER_NAME/$GIT_BRANCH
+DOCKER_TAGGED_BUILDS=("$DOCKER_REPO:latest" "$DOCKER_REPO:$SEM_VER")
 
 if [ "$GIT_BRANCH" = 'develop' -o "$GIT_BRANCH" = 'master' -o "$GIT_BRANCH" = 'main' ]
 then
@@ -14,8 +15,14 @@ then
   exit 1
 fi
 
-echo "building $DOCKER_TAGGED_BUILD"
-docker build -t "$DOCKER_TAGGED_BUILD" --build-arg SEM_VER=${SEM_VER} --build-arg BUILD_TIMESTAMP=${BUILD_TIMESTAMP} --build-arg GIT_BRANCH=${GIT_BRANCH} --build-arg COMMIT_HASH=${COMMIT_HASH} .
+for DOCKER_TAG in ${DOCKER_TAGGED_BUILDS[@]}
+do
+        echo "building $DOCKER_TAG"
+        docker build -t "$DOCKER_TAG" --build-arg SEM_VER=${SEM_VER} --build-arg BUILD_TIMESTAMP=${BUILD_TIMESTAMP} --build-arg GIT_BRANCH=${GIT_BRANCH} --build-arg COMMIT_HASH=${COMMIT_HASH} .
+done
 
-echo pushing to "$REPOSITORY"
-docker push "$DOCKER_TAGGED_BUILD"
+for DOCKER_TAG in ${DOCKER_TAGGED_BUILDS[@]}
+do
+        echo pushing to "$REPOSITORY"
+        docker push "$DOCKER_TAG"
+done

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -3,6 +3,7 @@ COMMIT_HASH=$(shell git rev-parse HEAD)
 GIT_BRANCH=$(shell git branch --show-current | tr '[:upper:]' '[:lower:]')
 GIT_VERSION=$(shell git branch --show-current | tr '[:upper:]' '[:lower:]')
 BUILD_TIMESTAMP=$(shell date +%s)
+export SEM_VER?=0.0.0
 
 .PHONY: help
 .DEFAULT_GOAL := help


### PR DESCRIPTION
Mizu can now be built with:
```sh
make docker
make cli
```

No need to fuss around with `SEM_VER` / docker tags.
CLI and agent versions will match each other, so CLI will use the correct image and `fetch`/`view` commands will work out of the box.
CD will not be affected because it explicitly sets `SEM_VER`.

`SEM_VER` can be set to a specific value via either a makefile variable or an environment variable.
```sh
# option 1
make docker SEM_VER=1.2.3
make cli SEM_VER=1.2.3

#option 2
export SEM_VER=1.2.3
make docker
make cli
```