### PR TITLE
Fix the memory exhaustion by optimizing max. AMQP message size and `GOGC`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build
 
 # Environment variables
 .env
+
+# pprof
+pprof/*

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -604,6 +604,7 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	agentContainer.WithEnv(
 		applyconfcore.EnvVar().WithName(shared.HostModeEnvVar).WithValue("1"),
 		applyconfcore.EnvVar().WithName(shared.TappedAddressesPerNodeDictEnvVar).WithValue(string(nodeToTappedPodIPMapJsonStr)),
+		applyconfcore.EnvVar().WithName(shared.GoGCEnvVar).WithValue("12800"),
 	)
 	agentContainer.WithEnv(
 		applyconfcore.EnvVar().WithName(shared.NodeNameEnvVar).WithValueFrom(

--- a/shared/consts.go
+++ b/shared/consts.go
@@ -8,4 +8,5 @@ const (
 	MaxEntriesDBSizeBytesEnvVar      = "MAX_ENTRIES_DB_BYTES"
 	RulePolicyPath                   = "/app/enforce-policy/"
 	RulePolicyFileName               = "enforce-policy.yaml"
+	GoGCEnvVar                       = "GOGC"
 )

--- a/tap/extensions/amqp/main.go
+++ b/tap/extensions/amqp/main.go
@@ -78,16 +78,11 @@ func (d dissecting) Dissect(b *bufio.Reader, isClient bool, tcpID *api.TcpID, co
 	var lastMethodFrameMessage Message
 
 	for {
-		// fmt.Printf("lastMethodFrameMessage: %v\n", lastMethodFrameMessage)
 		frame, err := r.ReadFrame()
 		if err == io.EOF {
 			// We must read until we see an EOF... very important!
 			return errors.New("AMQP EOF")
-		} else if err != nil {
-			// 	return err
 		}
-
-		// fmt.Printf("frame: %+v\n", frame)
 
 		switch f := frame.(type) {
 		case *HeartbeatFrame:

--- a/tap/extensions/amqp/main.go
+++ b/tap/extensions/amqp/main.go
@@ -78,18 +78,16 @@ func (d dissecting) Dissect(b *bufio.Reader, isClient bool, tcpID *api.TcpID, co
 	var lastMethodFrameMessage Message
 
 	for {
+		// fmt.Printf("lastMethodFrameMessage: %v\n", lastMethodFrameMessage)
 		frame, err := r.ReadFrame()
 		if err == io.EOF {
 			// We must read until we see an EOF... very important!
 			return errors.New("AMQP EOF")
 		} else if err != nil {
-			switch err.(type) {
-			case *Error:
-				if err.(*Error).Code == MaxHeaderFrameSizeError {
-					return err
-				}
-			}
+			// 	return err
 		}
+
+		// fmt.Printf("frame: %+v\n", frame)
 
 		switch f := frame.(type) {
 		case *HeartbeatFrame:

--- a/tap/extensions/amqp/read.go
+++ b/tap/extensions/amqp/read.go
@@ -54,7 +54,7 @@ func (r *AmqpReader) ReadFrame() (frame frame, err error) {
 	channel := binary.BigEndian.Uint16(scratch[1:3])
 	size := binary.BigEndian.Uint32(scratch[3:7])
 
-	if size > 1000000*128 {
+	if size > 1000000*16 {
 		return nil, ErrMaxSize
 	}
 

--- a/tap/extensions/amqp/spec091.go
+++ b/tap/extensions/amqp/spec091.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 )
 
@@ -19,33 +18,35 @@ import (
 // ErrCredentials.  The text of the error is likely more interesting than
 // these constants.
 const (
-	frameMethod             = 1
-	frameHeader             = 2
-	frameBody               = 3
-	frameHeartbeat          = 8
-	frameMinSize            = 4096
-	frameEnd                = 206
-	replySuccess            = 200
-	ContentTooLarge         = 311
-	NoRoute                 = 312
-	NoConsumers             = 313
-	ConnectionForced        = 320
-	InvalidPath             = 402
-	AccessRefused           = 403
-	NotFound                = 404
-	ResourceLocked          = 405
-	PreconditionFailed      = 406
-	FrameError              = 501
-	SyntaxError             = 502
-	CommandInvalid          = 503
-	ChannelError            = 504
-	UnexpectedFrame         = 505
-	ResourceError           = 506
-	NotAllowed              = 530
-	NotImplemented          = 540
-	InternalError           = 541
-	MaxSizeError            = 551
-	MaxHeaderFrameSizeError = 552
+	frameMethod                 = 1
+	frameHeader                 = 2
+	frameBody                   = 3
+	frameHeartbeat              = 8
+	frameMinSize                = 4096
+	frameEnd                    = 206
+	replySuccess                = 200
+	ContentTooLarge             = 311
+	NoRoute                     = 312
+	NoConsumers                 = 313
+	ConnectionForced            = 320
+	InvalidPath                 = 402
+	AccessRefused               = 403
+	NotFound                    = 404
+	ResourceLocked              = 405
+	PreconditionFailed          = 406
+	FrameError                  = 501
+	SyntaxError                 = 502
+	CommandInvalid              = 503
+	ChannelError                = 504
+	UnexpectedFrame             = 505
+	ResourceError               = 506
+	NotAllowed                  = 530
+	NotImplemented              = 540
+	InternalError               = 541
+	MaxSizeError                = 551
+	MaxHeaderFrameSizeError     = 552
+	BadMethodFrameUnknownMethod = 601
+	BadMethodFrameUnknownClass  = 602
 )
 
 func isSoftExceptionCode(code int) bool {
@@ -2855,7 +2856,8 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	case 20: // channel
@@ -2910,7 +2912,8 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	case 40: // exchange
@@ -2981,7 +2984,8 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	case 50: // queue
@@ -3068,7 +3072,8 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	case 60: // basic
@@ -3219,7 +3224,8 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	case 90: // tx
@@ -3274,7 +3280,8 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	case 85: // confirm
@@ -3297,11 +3304,13 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	default:
-		return nil, fmt.Errorf("Bad method frame, unknown class %d", mf.ClassId)
+		// log.Printf("Bad method frame, unknown class %d", mf.ClassId)
+		return nil, ErrBadMethodFrameUnknownClass
 	}
 
 	return mf, nil

--- a/tap/extensions/amqp/spec091.go
+++ b/tap/extensions/amqp/spec091.go
@@ -2856,7 +2856,6 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
@@ -2912,7 +2911,6 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
@@ -2984,7 +2982,6 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
@@ -3072,7 +3069,6 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
@@ -3224,7 +3220,6 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
@@ -3280,7 +3275,6 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
@@ -3304,12 +3298,10 @@ func (r *AmqpReader) parseMethodFrame(channel uint16, size uint32) (f frame, err
 			mf.Method = method
 
 		default:
-			// log.Printf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 			return nil, ErrBadMethodFrameUnknownMethod
 		}
 
 	default:
-		// log.Printf("Bad method frame, unknown class %d", mf.ClassId)
 		return nil, ErrBadMethodFrameUnknownClass
 	}
 

--- a/tap/extensions/amqp/spec091.go
+++ b/tap/extensions/amqp/spec091.go
@@ -19,32 +19,33 @@ import (
 // ErrCredentials.  The text of the error is likely more interesting than
 // these constants.
 const (
-	frameMethod        = 1
-	frameHeader        = 2
-	frameBody          = 3
-	frameHeartbeat     = 8
-	frameMinSize       = 4096
-	frameEnd           = 206
-	replySuccess       = 200
-	ContentTooLarge    = 311
-	NoRoute            = 312
-	NoConsumers        = 313
-	ConnectionForced   = 320
-	InvalidPath        = 402
-	AccessRefused      = 403
-	NotFound           = 404
-	ResourceLocked     = 405
-	PreconditionFailed = 406
-	FrameError         = 501
-	SyntaxError        = 502
-	CommandInvalid     = 503
-	ChannelError       = 504
-	UnexpectedFrame    = 505
-	ResourceError      = 506
-	NotAllowed         = 530
-	NotImplemented     = 540
-	InternalError      = 541
-	MaxSizeError       = 551
+	frameMethod             = 1
+	frameHeader             = 2
+	frameBody               = 3
+	frameHeartbeat          = 8
+	frameMinSize            = 4096
+	frameEnd                = 206
+	replySuccess            = 200
+	ContentTooLarge         = 311
+	NoRoute                 = 312
+	NoConsumers             = 313
+	ConnectionForced        = 320
+	InvalidPath             = 402
+	AccessRefused           = 403
+	NotFound                = 404
+	ResourceLocked          = 405
+	PreconditionFailed      = 406
+	FrameError              = 501
+	SyntaxError             = 502
+	CommandInvalid          = 503
+	ChannelError            = 504
+	UnexpectedFrame         = 505
+	ResourceError           = 506
+	NotAllowed              = 530
+	NotImplemented          = 540
+	InternalError           = 541
+	MaxSizeError            = 551
+	MaxHeaderFrameSizeError = 552
 )
 
 func isSoftExceptionCode(code int) bool {

--- a/tap/extensions/amqp/types.go
+++ b/tap/extensions/amqp/types.go
@@ -60,8 +60,9 @@ var (
 	// ErrFieldType is returned when writing a message containing a Go type unsupported by AMQP.
 	ErrFieldType = &Error{Code: SyntaxError, Reason: "unsupported table field type"}
 
-	// ErrClosed is returned when the channel or connection is not open
-	ErrMaxSize = &Error{Code: MaxSizeError, Reason: "an AMQP message cannot be bigger than 1MB"}
+	ErrMaxSize = &Error{Code: MaxSizeError, Reason: "an AMQP message cannot be bigger than 128MB"}
+
+	ErrMaxHeaderFrameSize = &Error{Code: MaxHeaderFrameSizeError, Reason: "an AMQP header cannot be bigger than 512 bytes"}
 )
 
 // Error captures the code and reason a channel or connection has been closed

--- a/tap/extensions/amqp/types.go
+++ b/tap/extensions/amqp/types.go
@@ -60,9 +60,13 @@ var (
 	// ErrFieldType is returned when writing a message containing a Go type unsupported by AMQP.
 	ErrFieldType = &Error{Code: SyntaxError, Reason: "unsupported table field type"}
 
-	ErrMaxSize = &Error{Code: MaxSizeError, Reason: "an AMQP message cannot be bigger than 128MB"}
+	ErrMaxSize = &Error{Code: MaxSizeError, Reason: "an AMQP message cannot be bigger than 16MB"}
 
 	ErrMaxHeaderFrameSize = &Error{Code: MaxHeaderFrameSizeError, Reason: "an AMQP header cannot be bigger than 512 bytes"}
+
+	ErrBadMethodFrameUnknownMethod = &Error{Code: BadMethodFrameUnknownMethod, Reason: "Bad method frame, unknown method"}
+
+	ErrBadMethodFrameUnknownClass = &Error{Code: BadMethodFrameUnknownClass, Reason: "Bad method frame, unknown class"}
 )
 
 // Error captures the code and reason a channel or connection has been closed

--- a/tap/extensions/http/handlers.go
+++ b/tap/extensions/http/handlers.go
@@ -79,14 +79,13 @@ func handleHTTP1ClientStream(b *bufio.Reader, tcpID *api.TcpID, counterPair *api
 	}
 	counterPair.Request++
 
-	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
 	req.Body = io.NopCloser(bytes.NewBuffer(body)) // rewind
 	s := len(body)
 	if err != nil {
 		rlog.Debugf("[HTTP-request-body] stream %s Got body err: %s", tcpID.Ident, err)
 	}
-	if err := defer req.Body.Close(); err != nil {
+	if err := req.Body.Close(); err != nil {
 		rlog.Debugf("[HTTP-request-body-close] stream %s Failed to close request body: %s", tcpID.Ident, err)
 	}
 	encoding := req.Header["Content-Encoding"]
@@ -122,14 +121,13 @@ func handleHTTP1ServerStream(b *bufio.Reader, tcpID *api.TcpID, counterPair *api
 	}
 	counterPair.Response++
 
-	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	res.Body = io.NopCloser(bytes.NewBuffer(body)) // rewind
 	s := len(body)
 	if err != nil {
 		rlog.Debugf("[HTTP-response-body] HTTP/%s: failed to get body(parsed len:%d): %s", tcpID.Ident, s, err)
 	}
-	if err := defer res.Body.Close(); err != nil {
+	if err := res.Body.Close(); err != nil {
 		rlog.Debugf("[HTTP-response-body-close] HTTP/%s: failed to close body(parsed len:%d): %s", tcpID.Ident, s, err)
 	}
 	sym := ","

--- a/tap/extensions/http/handlers.go
+++ b/tap/extensions/http/handlers.go
@@ -79,13 +79,14 @@ func handleHTTP1ClientStream(b *bufio.Reader, tcpID *api.TcpID, counterPair *api
 	}
 	counterPair.Request++
 
+	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
 	req.Body = io.NopCloser(bytes.NewBuffer(body)) // rewind
 	s := len(body)
 	if err != nil {
 		rlog.Debugf("[HTTP-request-body] stream %s Got body err: %s", tcpID.Ident, err)
 	}
-	if err := req.Body.Close(); err != nil {
+	if err := defer req.Body.Close(); err != nil {
 		rlog.Debugf("[HTTP-request-body-close] stream %s Failed to close request body: %s", tcpID.Ident, err)
 	}
 	encoding := req.Header["Content-Encoding"]
@@ -121,13 +122,14 @@ func handleHTTP1ServerStream(b *bufio.Reader, tcpID *api.TcpID, counterPair *api
 	}
 	counterPair.Response++
 
+	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	res.Body = io.NopCloser(bytes.NewBuffer(body)) // rewind
 	s := len(body)
 	if err != nil {
 		rlog.Debugf("[HTTP-response-body] HTTP/%s: failed to get body(parsed len:%d): %s", tcpID.Ident, s, err)
 	}
-	if err := res.Body.Close(); err != nil {
+	if err := defer res.Body.Close(); err != nil {
 		rlog.Debugf("[HTTP-response-body-close] HTTP/%s: failed to close body(parsed len:%d): %s", tcpID.Ident, s, err)
 	}
 	sym := ","

--- a/tap/settings.go
+++ b/tap/settings.go
@@ -7,6 +7,8 @@ import (
 
 const (
 	MemoryProfilingEnabledEnvVarName          = "MEMORY_PROFILING_ENABLED"
+	MemoryProfilingDumpPath                   = "MEMORY_PROFILING_DUMP_PATH"
+	MemoryProfilingTimeIntervalSeconds        = "MEMORY_PROFILING_TIME_INTERVAL"
 	MaxBufferedPagesTotalEnvVarName           = "MAX_BUFFERED_PAGES_TOTAL"
 	MaxBufferedPagesPerConnectionEnvVarName   = "MAX_BUFFERED_PAGES_PER_CONNECTION"
 	MaxBufferedPagesTotalDefaultValue         = 5000


### PR DESCRIPTION
Related to https://github.com/up9inc/mizu/pull/224

Sets maximum AMQP message size to 16MB

Adds one more fail-fast that checks max. header frame size of AMQP.

Sets `GOGC` to `12800` to trigger garbage collector less.

Does improvements in `startMemoryProfiler` method:
- Introduces `MEMORY_PROFILING_DUMP_PATH` environment variable.
- Introduces `MEMORY_PROFILING_TIME_INTERVAL` environment variable.

### Why setting `GOGC` to `12800`?

`GOGC`'s value is the criteria for Go's garbage collector triggering. It means the change in percentage of maximum allocated space compared to previous collection.

The dissectors constantly do allocations and quickly free them. This causes a lot of garbage collector triggering if it's set to `100`. A value like `12800` makes it less triggered. It actually reduces avg. memory usage because GC is less executed unnecessarily therefore jobs don't pile up.

Go runs its garbage collector at least every 2 ~seconds~ minutes no matter the value of `GOGC`. Also [see](https://github.com/up9inc/mizu/pull/257#issuecomment-913847182).

I've optimized it to `12800` by hand.

### Load Tests

I've run Sock Shop load tests for more than an hour with `--users 5 --spawn-rate 5 --headless` parameters. The peak memory usage was 312MB:

```
	User time (seconds): 906.36
	System time (seconds): 94.91
	Percent of CPU this job got: 25%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:05:19
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 312088
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 6173314
	Voluntary context switches: 25437585
	Involuntary context switches: 110789
	Swaps: 0
	File system inputs: 0
	File system outputs: 55216
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

![Screenshot from 2021-09-03 03-52-28](https://user-images.githubusercontent.com/2502080/131934291-43ae7c78-8498-4f63-9c05-4482383e5ce5.png)