### PR TITLE
Stop the hanging Goroutines by dropping the old, unidentified TCP streams

### DIFF
--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -72,10 +72,14 @@ type SuperTimer struct {
 	CaptureTime time.Time
 }
 
+type SuperIdentifier struct {
+	Protocol *Protocol
+}
+
 type Dissector interface {
 	Register(*Extension)
 	Ping()
-	Dissect(b *bufio.Reader, isClient bool, tcpID *TcpID, counterPair *CounterPair, superTimer *SuperTimer, emitter Emitter) error
+	Dissect(b *bufio.Reader, isClient bool, tcpID *TcpID, counterPair *CounterPair, superTimer *SuperTimer, superIdentifier *SuperIdentifier, emitter Emitter) error
 	Analyze(item *OutputChannelItem, entryId string, resolvedSource string, resolvedDestination string) *MizuEntry
 	Summarize(entry *MizuEntry) *BaseEntryDetails
 	Represent(entry *MizuEntry) (protocol Protocol, object []byte, bodySize int64, err error)

--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -21,7 +21,7 @@ type Protocol struct {
 }
 
 type Extension struct {
-	Protocol   Protocol
+	Protocol   *Protocol
 	Path       string
 	Plug       *plugin.Plugin
 	Dissector  Dissector
@@ -73,7 +73,8 @@ type SuperTimer struct {
 }
 
 type SuperIdentifier struct {
-	Protocol *Protocol
+	Protocol       *Protocol
+	IsClosedOthers bool
 }
 
 type Dissector interface {

--- a/tap/extensions/amqp/main.go
+++ b/tap/extensions/amqp/main.go
@@ -32,7 +32,7 @@ func init() {
 type dissecting string
 
 func (d dissecting) Register(extension *api.Extension) {
-	extension.Protocol = protocol
+	extension.Protocol = &protocol
 }
 
 func (d dissecting) Ping() {

--- a/tap/extensions/http/main.go
+++ b/tap/extensions/http/main.go
@@ -53,7 +53,7 @@ func init() {
 type dissecting string
 
 func (d dissecting) Register(extension *api.Extension) {
-	extension.Protocol = protocol
+	extension.Protocol = &protocol
 	extension.MatcherMap = reqResMatcher.openMessagesMap
 }
 

--- a/tap/extensions/kafka/main.go
+++ b/tap/extensions/kafka/main.go
@@ -31,7 +31,7 @@ func init() {
 type dissecting string
 
 func (d dissecting) Register(extension *api.Extension) {
-	extension.Protocol = _protocol
+	extension.Protocol = &_protocol
 	extension.MatcherMap = reqResMatcher.openMessagesMap
 }
 

--- a/tap/extensions/kafka/main.go
+++ b/tap/extensions/kafka/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -38,18 +39,24 @@ func (d dissecting) Ping() {
 	log.Printf("pong %s\n", _protocol.Name)
 }
 
-func (d dissecting) Dissect(b *bufio.Reader, isClient bool, tcpID *api.TcpID, counterPair *api.CounterPair, superTimer *api.SuperTimer, emitter api.Emitter) error {
+func (d dissecting) Dissect(b *bufio.Reader, isClient bool, tcpID *api.TcpID, counterPair *api.CounterPair, superTimer *api.SuperTimer, superIdentifier *api.SuperIdentifier, emitter api.Emitter) error {
 	for {
+		if superIdentifier.Protocol != nil && superIdentifier.Protocol != &_protocol {
+			return errors.New("Identified by another protocol")
+		}
+
 		if isClient {
 			_, _, err := ReadRequest(b, tcpID, superTimer)
 			if err != nil {
 				return err
 			}
+			superIdentifier.Protocol = &_protocol
 		} else {
 			err := ReadResponse(b, tcpID, superTimer, emitter)
 			if err != nil {
 				return err
 			}
+			superIdentifier.Protocol = &_protocol
 		}
 	}
 }

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -226,7 +226,6 @@ func closeTimedoutTcpStreamChannels() {
 			if !stream.isClosed && stream.superIdentifier.Protocol == nil && time.Now().After(streamWrapper.createdAt.Add(time.Duration(dynamicStreamChannelTimeoutNs))) {
 				stream.Close()
 				statsTracker.incDroppedTcpStreams()
-				fmt.Printf("Dropped an unidentified TCP stream because of load. Total dropped: %d Goroutine metric: %f Total Goroutines: %d Timeout (ms): %d\n", statsTracker.appStats.DroppedTcpStreams, metric, n, dynamicStreamChannelTimeoutMs)
 				rlog.Debugf("Dropped an unidentified TCP stream because of load. Total dropped: %d Goroutine metric: %f Total Goroutines: %d Timeout (ms): %d\n", statsTracker.appStats.DroppedTcpStreams, metric, n, dynamicStreamChannelTimeoutMs)
 			}
 			return true

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -207,7 +207,7 @@ func closeTimedoutTcpStreamChannels() {
 	// +1 Main packet capture loop
 	baseGoroutineCount := runtime.NumGoroutine() + 2
 	for {
-		runtime.Gosched()
+		time.Sleep(1 * time.Millisecond)
 		streams.Range(func(key interface{}, value interface{}) bool {
 			streamWrapper := value.(*tcpStreamWrapper)
 			stream := streamWrapper.stream

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -213,8 +213,11 @@ func closeTimedoutTcpStreamChannels() {
 			if metric < 1 {
 				metric = 1
 			}
+			// `metric` stabilizes arround 0 - 24.
+			// `metric` means number of currently running extra Goroutines mainly spawned for dissectors.
+			// fmt.Printf("metric: %v\n", metric)
 			dynamicStreamChannelTimeoutNs := baseStreamChannelTimeoutMs * cpuCount / metric * 1000000
-			if !stream.isClosed && time.Now().After(streamWrapper.createdAt.Add(time.Duration(dynamicStreamChannelTimeoutNs))) {
+			if !stream.isClosed && stream.superIdentifier.Protocol == nil && time.Now().After(streamWrapper.createdAt.Add(time.Duration(dynamicStreamChannelTimeoutNs))) {
 				stream.Close()
 				statsTracker.incDroppedTcpStreams()
 				rlog.Debugf("Dropped a TCP stream because of load. Total dropped: %d\n", statsTracker.appStats.DroppedTcpStreams)

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -216,6 +216,8 @@ func closeTimedoutTcpStreamChannels() {
 			dynamicStreamChannelTimeoutNs := baseStreamChannelTimeoutMs * cpuCount / metric * 1000000
 			if !stream.isClosed && time.Now().After(streamWrapper.createdAt.Add(time.Duration(dynamicStreamChannelTimeoutNs))) {
 				stream.Close()
+				statsTracker.incDroppedTcpStreams()
+				rlog.Debugf("Dropped a TCP stream because of load. Total dropped: %d\n", statsTracker.appStats.DroppedTcpStreams)
 			}
 			return true
 		})

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -215,20 +215,7 @@ func closeTimedoutTcpStreamChannels() {
 			}
 			dynamicStreamChannelTimeoutNs := baseStreamChannelTimeoutMs * cpuCount / metric * 1000000
 			if !stream.isClosed && time.Now().After(streamWrapper.createdAt.Add(time.Duration(dynamicStreamChannelTimeoutNs))) {
-				stream.Lock()
-				stream.isClosed = true
-				stream.Unlock()
-				streams.Delete(key)
-				for _, reader := range stream.clients {
-					stream.Lock()
-					close(reader.msgQueue)
-					stream.Unlock()
-				}
-				for _, reader := range stream.servers {
-					stream.Lock()
-					close(reader.msgQueue)
-					stream.Unlock()
-				}
+				stream.Close()
 			}
 			return true
 		})

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -302,7 +302,7 @@ func startPassiveTapper(outputItems chan *api.OutputChannelItem) {
 		log.Fatalln("No decoder named", decoderName)
 	}
 	source := gopacket.NewPacketSource(handle, dec)
-	// source.Lazy = *lazy
+	source.Lazy = *lazy
 	source.NoCopy = true
 	rlog.Info("Starting to read packets")
 	statsTracker.setStartTime(time.Now())

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -227,6 +227,20 @@ func closeTimedoutTcpStreamChannels() {
 				stream.Close()
 				statsTracker.incDroppedTcpStreams()
 				rlog.Debugf("Dropped an unidentified TCP stream because of load. Total dropped: %d Goroutine metric: %f Total Goroutines: %d Timeout (ms): %d\n", statsTracker.appStats.DroppedTcpStreams, metric, n, dynamicStreamChannelTimeoutMs)
+			} else if stream.superIdentifier.Protocol != nil && !stream.superIdentifier.IsClosedOthers {
+				for i := range stream.clients {
+					reader := &stream.clients[i]
+					if reader.extension.Protocol != stream.superIdentifier.Protocol {
+						reader.Close()
+					}
+				}
+				for i := range stream.servers {
+					reader := &stream.servers[i]
+					if reader.extension.Protocol != stream.superIdentifier.Protocol {
+						reader.Close()
+					}
+				}
+				stream.superIdentifier.IsClosedOthers = true
 			}
 			return true
 		})

--- a/tap/settings.go
+++ b/tap/settings.go
@@ -3,14 +3,19 @@ package tap
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 const (
 	MemoryProfilingEnabledEnvVarName          = "MEMORY_PROFILING_ENABLED"
 	MaxBufferedPagesTotalEnvVarName           = "MAX_BUFFERED_PAGES_TOTAL"
 	MaxBufferedPagesPerConnectionEnvVarName   = "MAX_BUFFERED_PAGES_PER_CONNECTION"
+	TcpStreamChannelTimeoutMsEnvVarName       = "TCP_STREAM_CHANNEL_TIMEOUT_MS"
+	MaxNumberOfGoroutinesEnvVarName           = "MAX_NUMBER_OF_GOROUTINES"
 	MaxBufferedPagesTotalDefaultValue         = 5000
 	MaxBufferedPagesPerConnectionDefaultValue = 5000
+	TcpStreamChannelTimeoutMsDefaultValue     = 5000
+	MaxNumberOfGoroutinesDefaultValue         = 4000
 )
 
 type globalSettings struct {
@@ -43,6 +48,22 @@ func GetMaxBufferedPagesPerConnection() int {
 	valueFromEnv, err := strconv.Atoi(os.Getenv(MaxBufferedPagesPerConnectionEnvVarName))
 	if err != nil {
 		return MaxBufferedPagesPerConnectionDefaultValue
+	}
+	return valueFromEnv
+}
+
+func GetTcpChannelTimeoutMs() time.Duration {
+	valueFromEnv, err := strconv.Atoi(os.Getenv(TcpStreamChannelTimeoutMsEnvVarName))
+	if err != nil {
+		return TcpStreamChannelTimeoutMsDefaultValue * time.Millisecond
+	}
+	return time.Duration(valueFromEnv) * time.Millisecond
+}
+
+func GetMaxNumberOfGoroutines() int {
+	valueFromEnv, err := strconv.Atoi(os.Getenv(MaxNumberOfGoroutinesEnvVarName))
+	if err != nil {
+		return MaxNumberOfGoroutinesDefaultValue
 	}
 	return valueFromEnv
 }

--- a/tap/stats_tracker.go
+++ b/tap/stats_tracker.go
@@ -13,6 +13,7 @@ type AppStats struct {
 	ReassembledTcpPayloadsCount int64     `json:"reassembledTcpPayloadsCount"`
 	TlsConnectionsCount         int64     `json:"tlsConnectionsCount"`
 	MatchedPairs                int64     `json:"matchedPairs"`
+	DroppedTcpStreams           int64     `json:"droppedTcpStreams"`
 }
 
 type StatsTracker struct {
@@ -23,12 +24,19 @@ type StatsTracker struct {
 	reassembledTcpPayloadsCountMutex sync.Mutex
 	tlsConnectionsCountMutex         sync.Mutex
 	matchedPairsMutex                sync.Mutex
+	droppedTcpStreamsMutex           sync.Mutex
 }
 
 func (st *StatsTracker) incMatchedPairs() {
 	st.matchedPairsMutex.Lock()
 	st.appStats.MatchedPairs++
 	st.matchedPairsMutex.Unlock()
+}
+
+func (st *StatsTracker) incDroppedTcpStreams() {
+	st.droppedTcpStreamsMutex.Lock()
+	st.appStats.DroppedTcpStreams++
+	st.droppedTcpStreamsMutex.Unlock()
 }
 
 func (st *StatsTracker) incPacketsCount() int64 {
@@ -99,6 +107,11 @@ func (st *StatsTracker) dumpStats() *AppStats {
 	currentAppStats.MatchedPairs = st.appStats.MatchedPairs
 	st.appStats.MatchedPairs = 0
 	st.matchedPairsMutex.Unlock()
+
+	st.droppedTcpStreamsMutex.Lock()
+	currentAppStats.DroppedTcpStreams = st.appStats.DroppedTcpStreams
+	st.appStats.DroppedTcpStreams = 0
+	st.droppedTcpStreamsMutex.Unlock()
 
 	return currentAppStats
 }

--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -96,7 +96,7 @@ func (h *tcpReader) Read(p []byte) (int, error) {
 func (h *tcpReader) run(wg *sync.WaitGroup) {
 	defer wg.Done()
 	b := bufio.NewReader(h)
-	err := h.extension.Dissector.Dissect(b, h.isClient, h.tcpID, h.counterPair, h.superTimer, h.emitter)
+	err := h.extension.Dissector.Dissect(b, h.isClient, h.tcpID, h.counterPair, h.superTimer, h.parent.superIdentifier, h.emitter)
 	if err != nil {
 		io.Copy(ioutil.Discard, b)
 	}

--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -95,6 +95,15 @@ func (h *tcpReader) Read(p []byte) (int, error) {
 	return l, nil
 }
 
+func (h *tcpReader) Close() {
+	h.Lock()
+	if !h.isClosed {
+		h.isClosed = true
+		close(h.msgQueue)
+	}
+	h.Unlock()
+}
+
 func (h *tcpReader) run(wg *sync.WaitGroup) {
 	defer wg.Done()
 	b := bufio.NewReader(h)

--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -47,6 +47,7 @@ func (tid *tcpID) String() string {
 type tcpReader struct {
 	ident              string
 	tcpID              *api.TcpID
+	isClosed           bool
 	isClient           bool
 	isOutgoing         bool
 	msgQueue           chan tcpReaderDataMsg // Channel of captured reassembled tcp payload
@@ -59,6 +60,7 @@ type tcpReader struct {
 	extension          *api.Extension
 	emitter            api.Emitter
 	counterPair        *api.CounterPair
+	sync.Mutex
 }
 
 func (h *tcpReader) Read(p []byte) (int, error) {

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -197,20 +197,10 @@ func (t *tcpStream) Close() {
 
 	for i := range t.clients {
 		reader := &t.clients[i]
-		reader.Lock()
-		if !reader.isClosed {
-			reader.isClosed = true
-			close(reader.msgQueue)
-		}
-		reader.Unlock()
+		reader.Close()
 	}
 	for i := range t.servers {
 		reader := &t.servers[i]
-		reader.Lock()
-		if !reader.isClosed {
-			reader.isClosed = true
-			close(reader.msgQueue)
-		}
-		reader.Unlock()
+		reader.Close()
 	}
 }

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -169,6 +169,7 @@ func (t *tcpStream) ReassemblyComplete(ac reassembly.AssemblerContext) bool {
 		t.Lock()
 		t.isClosed = true
 		t.Unlock()
+		streams.Delete(t.id)
 		for _, reader := range t.clients {
 			t.Lock()
 			close(reader.msgQueue)

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -167,21 +167,25 @@ func (t *tcpStream) ReassembledSG(sg reassembly.ScatterGather, ac reassembly.Ass
 func (t *tcpStream) ReassemblyComplete(ac reassembly.AssemblerContext) bool {
 	Trace("%s: Connection closed", t.ident)
 	if t.isTapTarget && !t.isClosed {
-		t.Lock()
-		t.isClosed = true
-		t.Unlock()
-		streams.Delete(t.id)
-		for _, reader := range t.clients {
-			t.Lock()
-			close(reader.msgQueue)
-			t.Unlock()
-		}
-		for _, reader := range t.servers {
-			t.Lock()
-			close(reader.msgQueue)
-			t.Unlock()
-		}
+		t.Close()
 	}
 	// do not remove the connection to allow last ACK
 	return false
+}
+
+func (t *tcpStream) Close() {
+	t.Lock()
+	t.isClosed = true
+	t.Unlock()
+	streams.Delete(t.id)
+	for _, reader := range t.clients {
+		t.Lock()
+		close(reader.msgQueue)
+		t.Unlock()
+	}
+	for _, reader := range t.servers {
+		t.Lock()
+		close(reader.msgQueue)
+		t.Unlock()
+	}
 }

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers" // pulls in all layers decoders
 	"github.com/google/gopacket/reassembly"
+	"github.com/up9inc/mizu/tap/api"
 )
 
 /* It's a connection (bidirectional)
@@ -16,18 +17,19 @@ import (
  * In our implementation, we pass information from ReassembledSG to the tcpReader through a shared channel.
  */
 type tcpStream struct {
-	id             int64
-	isClosed       bool
-	tcpstate       *reassembly.TCPSimpleFSM
-	fsmerr         bool
-	optchecker     reassembly.TCPOptionCheck
-	net, transport gopacket.Flow
-	isDNS          bool
-	isTapTarget    bool
-	clients        []tcpReader
-	servers        []tcpReader
-	urls           []string
-	ident          string
+	id              int64
+	isClosed        bool
+	superIdentifier *api.SuperIdentifier
+	tcpstate        *reassembly.TCPSimpleFSM
+	fsmerr          bool
+	optchecker      reassembly.TCPOptionCheck
+	net, transport  gopacket.Flow
+	isDNS           bool
+	isTapTarget     bool
+	clients         []tcpReader
+	servers         []tcpReader
+	urls            []string
+	ident           string
 	sync.Mutex
 }
 

--- a/tap/tcp_stream_factory.go
+++ b/tap/tcp_stream_factory.go
@@ -50,13 +50,14 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcp *layers.T
 	props := factory.getStreamProps(srcIp, srcPort, dstIp, dstPort)
 	isTapTarget := props.isTapTarget
 	stream := &tcpStream{
-		net:         net,
-		transport:   transport,
-		isDNS:       tcp.SrcPort == 53 || tcp.DstPort == 53,
-		isTapTarget: isTapTarget,
-		tcpstate:    reassembly.NewTCPSimpleFSM(fsmOptions),
-		ident:       fmt.Sprintf("%s:%s", net, transport),
-		optchecker:  reassembly.NewTCPOptionCheck(),
+		net:             net,
+		transport:       transport,
+		isDNS:           tcp.SrcPort == 53 || tcp.DstPort == 53,
+		isTapTarget:     isTapTarget,
+		tcpstate:        reassembly.NewTCPSimpleFSM(fsmOptions),
+		ident:           fmt.Sprintf("%s:%s", net, transport),
+		optchecker:      reassembly.NewTCPOptionCheck(),
+		superIdentifier: &api.SuperIdentifier{},
 	}
 	if stream.isTapTarget {
 		streamId++

--- a/tap/tcp_stream_factory.go
+++ b/tap/tcp_stream_factory.go
@@ -29,8 +29,6 @@ type tcpStreamWrapper struct {
 	createdAt time.Time
 }
 
-const baseStreamChannelTimeoutMs int = 5000
-
 var streams *sync.Map = &sync.Map{} // global
 var streamId int64 = 0
 

--- a/tap/tcp_stream_factory.go
+++ b/tap/tcp_stream_factory.go
@@ -29,7 +29,7 @@ type tcpStreamWrapper struct {
 	createdAt time.Time
 }
 
-const baseStreamChannelTimeoutMs int = 10000
+const baseStreamChannelTimeoutMs int = 5000
 
 var streams *sync.Map = &sync.Map{} // global
 var streamId int64 = 0


### PR DESCRIPTION
Related to https://github.com/up9inc/mizu/pull/224

Closes the hanging TCP message channels after a dynamically aligned timeout (base `500000` milliseconds).

https://github.com/up9inc/mizu/blob/aa24ee37791ca00741dbfb0f78e9334d6a3b344f/tap/passive_tapper.go#L98

Since all ports are listened now, in most cases,

https://github.com/up9inc/mizu/blob/f13152d619004de98d15b191e4ca3e1a3e37b97b/tap/tcp_stream.go#L166

is not called. Therefore the channels do not close:

https://github.com/up9inc/mizu/blob/f13152d619004de98d15b191e4ca3e1a3e37b97b/tap/tcp_reader.go#L52

and in some cases Goroutines pile up. Because `Read` does not return (falls into infinite loop):

https://github.com/up9inc/mizu/blob/f13152d619004de98d15b191e4ca3e1a3e37b97b/tap/tcp_reader.go#L69

This PR closes the TCP message channels based on the formula below:

https://github.com/up9inc/mizu/blob/aa24ee37791ca00741dbfb0f78e9334d6a3b344f/tap/passive_tapper.go#L214-L225

_**500000** x **CPU core count** / (**Number of currently running Goroutines** - **Base Goroutine count**) (ms)_

Moved from `Packets` to `NextPacket`:

https://github.com/up9inc/mizu/blob/f13152d619004de98d15b191e4ca3e1a3e37b97b/tap/passive_tapper.go#L388

The documentation says:

> This method is the most flexible, and exposes errors that may be encountered by the underlying PacketDataSource. It's also the fastest in a tight loop, since it doesn't have the overhead of a channel read/write. However, it requires the user to handle errors, most importantly the io.EOF error in cases where packets are being read from a file. - [source](https://pkg.go.dev/github.com/google/gopacket#hdr-Reading_With_NextPacket_Function)

### Test Results

It stabilizes arround these values:

```
Total dropped: 1780 Goroutine metric: 0.003213 Total Goroutines: 3748 Timeout (ms): 1606
```

no matter what the load is or the resources are.

On my machine;

For the `locust --host http://192.168.49.2:30001 -f load_dev.py --users 100 --spawn-rate 100 --headless` the drop rate was 0.1% - 0.5%. 

```
2021/09/05 10:18:34 passive_tapper.go:386: app stats - {"processedBytes":258225879,"packetsCount":626898,"tcpPacketsCount":574718,"reassembledTcpPayloadsCount":176064,"tlsConnectionsCount":0,"matchedPairs":0,"droppedTcpStreams":9797}
```

For `locust --host http://192.168.49.2:30001 -f load_dev.py --users 50 --spawn-rate 50 --headless` it was ignorable.

Better machines would have less drop rate.

### Conclusion

`ReassemblyComplete` is not guaranteed to be called. Especially the reassembly does not finish for TLS connections in most cases. I tried putting `return 0, io.EOF` to here:

https://github.com/up9inc/mizu/blob/39ea02250ef61162e57a9e2bb247725a99b1a732/tap/tcp_reader.go#L80

and putting `layers.LayerTypeTLS` check in here:

https://github.com/up9inc/mizu/blob/39ea02250ef61162e57a9e2bb247725a99b1a732/tap/passive_tapper.go#L426-L427

But they didn't work. Therefore I came up with this solution. It might not be the best solution but it prevents the overloads at least.

_There are [issues](https://github.com/google/gopacket/issues?q=is%3Aissue+TLS) like [this one](https://github.com/google/gopacket/issues/905) in `gopacket` related to TLS that worth noting._

_Even though we rule out the TLS connections. There could still be a need for such a dropping mechanism. Since the issue is **not TLS specific**._

---

**Addition:** [See](https://github.com/up9inc/mizu/pull/260#issuecomment-913079684).