### PR TITLE
Turn `table` and `body` strings to constants and move them to extension API

### DIFF
--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -169,3 +169,8 @@ func (bed *BaseEntryDetails) UnmarshalData(entry *MizuEntry) error {
 	bed.IsOutgoing = entry.IsOutgoing
 	return nil
 }
+
+const (
+	TABLE string = "table"
+	BODY  string = "body"
+)

--- a/tap/extensions/amqp/helpers.go
+++ b/tap/extensions/amqp/helpers.go
@@ -219,7 +219,7 @@ func representProperties(properties map[string]interface{}, rep []interface{}) (
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Properties",
 		"data":  string(props),
 	})
@@ -249,7 +249,7 @@ func representBasicPublish(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -267,7 +267,7 @@ func representBasicPublish(event map[string]interface{}) []interface{} {
 		}
 		headersMarshaled, _ := json.Marshal(headers)
 		rep = append(rep, map[string]string{
-			"type":  "table",
+			"type":  api.TABLE,
 			"title": "Headers",
 			"data":  string(headersMarshaled),
 		})
@@ -275,7 +275,7 @@ func representBasicPublish(event map[string]interface{}) []interface{} {
 
 	if event["Body"] != nil {
 		rep = append(rep, map[string]string{
-			"type":      "body",
+			"type":      api.BODY,
 			"title":     "Body",
 			"encoding":  "base64",
 			"mime_type": contentType,
@@ -326,7 +326,7 @@ func representBasicDeliver(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -344,7 +344,7 @@ func representBasicDeliver(event map[string]interface{}) []interface{} {
 		}
 		headersMarshaled, _ := json.Marshal(headers)
 		rep = append(rep, map[string]string{
-			"type":  "table",
+			"type":  api.TABLE,
 			"title": "Headers",
 			"data":  string(headersMarshaled),
 		})
@@ -352,7 +352,7 @@ func representBasicDeliver(event map[string]interface{}) []interface{} {
 
 	if event["Body"] != nil {
 		rep = append(rep, map[string]string{
-			"type":      "body",
+			"type":      api.BODY,
 			"title":     "Body",
 			"encoding":  "base64",
 			"mime_type": contentType,
@@ -393,7 +393,7 @@ func representQueueDeclare(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -408,7 +408,7 @@ func representQueueDeclare(event map[string]interface{}) []interface{} {
 		}
 		headersMarshaled, _ := json.Marshal(headers)
 		rep = append(rep, map[string]string{
-			"type":  "table",
+			"type":  api.TABLE,
 			"title": "Arguments",
 			"data":  string(headersMarshaled),
 		})
@@ -451,7 +451,7 @@ func representExchangeDeclare(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -466,7 +466,7 @@ func representExchangeDeclare(event map[string]interface{}) []interface{} {
 		}
 		headersMarshaled, _ := json.Marshal(headers)
 		rep = append(rep, map[string]string{
-			"type":  "table",
+			"type":  api.TABLE,
 			"title": "Arguments",
 			"data":  string(headersMarshaled),
 		})
@@ -497,7 +497,7 @@ func representConnectionStart(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -524,7 +524,7 @@ func representConnectionStart(event map[string]interface{}) []interface{} {
 		}
 		headersMarshaled, _ := json.Marshal(headers)
 		rep = append(rep, map[string]string{
-			"type":  "table",
+			"type":  api.TABLE,
 			"title": "Server Properties",
 			"data":  string(headersMarshaled),
 		})
@@ -555,7 +555,7 @@ func representConnectionClose(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -585,7 +585,7 @@ func representQueueBind(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -600,7 +600,7 @@ func representQueueBind(event map[string]interface{}) []interface{} {
 		}
 		headersMarshaled, _ := json.Marshal(headers)
 		rep = append(rep, map[string]string{
-			"type":  "table",
+			"type":  api.TABLE,
 			"title": "Arguments",
 			"data":  string(headersMarshaled),
 		})
@@ -639,7 +639,7 @@ func representBasicConsume(event map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
@@ -654,7 +654,7 @@ func representBasicConsume(event map[string]interface{}) []interface{} {
 		}
 		headersMarshaled, _ := json.Marshal(headers)
 		rep = append(rep, map[string]string{
-			"type":  "table",
+			"type":  api.TABLE,
 			"title": "Arguments",
 			"data":  string(headersMarshaled),
 		})

--- a/tap/extensions/http/main.go
+++ b/tap/extensions/http/main.go
@@ -234,28 +234,28 @@ func representRequest(request map[string]interface{}) (repRequest []interface{})
 		},
 	})
 	repRequest = append(repRequest, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
 
 	headers, _ := json.Marshal(request["headers"].([]interface{}))
 	repRequest = append(repRequest, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Headers",
 		"data":  string(headers),
 	})
 
 	cookies, _ := json.Marshal(request["cookies"].([]interface{}))
 	repRequest = append(repRequest, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Cookies",
 		"data":  string(cookies),
 	})
 
 	queryString, _ := json.Marshal(request["queryString"].([]interface{}))
 	repRequest = append(repRequest, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Query String",
 		"data":  string(queryString),
 	})
@@ -268,7 +268,7 @@ func representRequest(request map[string]interface{}) (repRequest []interface{})
 	text, _ := postData["text"]
 	if text != nil {
 		repRequest = append(repRequest, map[string]string{
-			"type":      "body",
+			"type":      api.BODY,
 			"title":     "POST Data (text/plain)",
 			"encoding":  "",
 			"mime_type": mimeType.(string),
@@ -287,13 +287,13 @@ func representRequest(request map[string]interface{}) (repRequest []interface{})
 					},
 				})
 				repRequest = append(repRequest, map[string]string{
-					"type":  "table",
+					"type":  api.TABLE,
 					"title": "POST Data (multipart/form-data)",
 					"data":  string(multipart),
 				})
 			} else {
 				repRequest = append(repRequest, map[string]string{
-					"type":  "table",
+					"type":  api.TABLE,
 					"title": "POST Data (application/x-www-form-urlencoded)",
 					"data":  string(params),
 				})
@@ -324,21 +324,21 @@ func representResponse(response map[string]interface{}) (repResponse []interface
 		},
 	})
 	repResponse = append(repResponse, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Details",
 		"data":  string(details),
 	})
 
 	headers, _ := json.Marshal(response["headers"].([]interface{}))
 	repResponse = append(repResponse, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Headers",
 		"data":  string(headers),
 	})
 
 	cookies, _ := json.Marshal(response["cookies"].([]interface{}))
 	repResponse = append(repResponse, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Cookies",
 		"data":  string(cookies),
 	})
@@ -352,7 +352,7 @@ func representResponse(response map[string]interface{}) (repResponse []interface
 	text, _ := content["text"]
 	if text != nil {
 		repResponse = append(repResponse, map[string]string{
-			"type":      "body",
+			"type":      api.BODY,
 			"title":     "Body",
 			"encoding":  encoding.(string),
 			"mime_type": mimeType.(string),

--- a/tap/extensions/kafka/helpers.go
+++ b/tap/extensions/kafka/helpers.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"github.com/up9inc/mizu/tap/api"
 )
 
 type KafkaPayload struct {
@@ -48,7 +50,7 @@ func representRequestHeader(data map[string]interface{}, rep []interface{}) []in
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Request Header",
 		"data":  string(requestHeader),
 	})
@@ -64,7 +66,7 @@ func representResponseHeader(data map[string]interface{}, rep []interface{}) []i
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Response Header",
 		"data":  string(requestHeader),
 	})
@@ -114,7 +116,7 @@ func representMetadataRequest(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -173,7 +175,7 @@ func representMetadataResponse(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -206,7 +208,7 @@ func representApiVersionsRequest(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -244,7 +246,7 @@ func representApiVersionsResponse(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -287,7 +289,7 @@ func representProduceRequest(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -317,7 +319,7 @@ func representProduceResponse(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -404,7 +406,7 @@ func representFetchRequest(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -450,7 +452,7 @@ func representFetchResponse(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -476,7 +478,7 @@ func representListOffsetsRequest(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -506,7 +508,7 @@ func representListOffsetsResponse(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -540,7 +542,7 @@ func representCreateTopicsRequest(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -570,7 +572,7 @@ func representCreateTopicsResponse(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -609,7 +611,7 @@ func representDeleteTopicsRequest(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})
@@ -639,7 +641,7 @@ func representDeleteTopicsResponse(data map[string]interface{}) []interface{} {
 		},
 	})
 	rep = append(rep, map[string]string{
-		"type":  "table",
+		"type":  api.TABLE,
 		"title": "Payload",
 		"data":  string(repPayload),
 	})


### PR DESCRIPTION
Moves them to a single place to reduce duplication.