### PR TITLE
Fix the `OOMKilled` error by calling `debug.FreeOSMemory` periodically

### DIFF
--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -218,8 +218,8 @@ func startMemoryProfiler() {
 func closeTimedoutTcpStreamChannels() {
 	TcpStreamChannelTimeoutMs := GetTcpChannelTimeoutMs()
 	for {
-		_debug.FreeOSMemory()
 		time.Sleep(10 * time.Millisecond)
+		_debug.FreeOSMemory()
 		streams.Range(func(key interface{}, value interface{}) bool {
 			streamWrapper := value.(*tcpStreamWrapper)
 			stream := streamWrapper.stream

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	_debug "runtime/debug"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -218,6 +219,7 @@ func closeTimedoutTcpStreamChannels() {
 	maxNumberOfGoroutines = GetMaxNumberOfGoroutines()
 	TcpStreamChannelTimeoutMs := GetTcpChannelTimeoutMs()
 	for {
+		_debug.FreeOSMemory()
 		time.Sleep(10 * time.Millisecond)
 		streams.Range(func(key interface{}, value interface{}) bool {
 			streamWrapper := value.(*tcpStreamWrapper)

--- a/tap/passive_tapper.go
+++ b/tap/passive_tapper.go
@@ -216,7 +216,6 @@ func startMemoryProfiler() {
 }
 
 func closeTimedoutTcpStreamChannels() {
-	maxNumberOfGoroutines = GetMaxNumberOfGoroutines()
 	TcpStreamChannelTimeoutMs := GetTcpChannelTimeoutMs()
 	for {
 		_debug.FreeOSMemory()

--- a/tap/settings.go
+++ b/tap/settings.go
@@ -15,7 +15,7 @@ const (
 	TcpStreamChannelTimeoutMsEnvVarName       = "TCP_STREAM_CHANNEL_TIMEOUT_MS"
 	MaxBufferedPagesTotalDefaultValue         = 5000
 	MaxBufferedPagesPerConnectionDefaultValue = 5000
-	TcpStreamChannelTimeoutMsDefaultValue     = 5000
+	TcpStreamChannelTimeoutMsDefaultValue     = 10000
 )
 
 type globalSettings struct {

--- a/tap/settings.go
+++ b/tap/settings.go
@@ -13,11 +13,9 @@ const (
 	MaxBufferedPagesTotalEnvVarName           = "MAX_BUFFERED_PAGES_TOTAL"
 	MaxBufferedPagesPerConnectionEnvVarName   = "MAX_BUFFERED_PAGES_PER_CONNECTION"
 	TcpStreamChannelTimeoutMsEnvVarName       = "TCP_STREAM_CHANNEL_TIMEOUT_MS"
-	MaxNumberOfGoroutinesEnvVarName           = "MAX_NUMBER_OF_GOROUTINES"
 	MaxBufferedPagesTotalDefaultValue         = 5000
 	MaxBufferedPagesPerConnectionDefaultValue = 5000
 	TcpStreamChannelTimeoutMsDefaultValue     = 5000
-	MaxNumberOfGoroutinesDefaultValue         = 4000
 )
 
 type globalSettings struct {
@@ -60,14 +58,6 @@ func GetTcpChannelTimeoutMs() time.Duration {
 		return TcpStreamChannelTimeoutMsDefaultValue * time.Millisecond
 	}
 	return time.Duration(valueFromEnv) * time.Millisecond
-}
-
-func GetMaxNumberOfGoroutines() int {
-	valueFromEnv, err := strconv.Atoi(os.Getenv(MaxNumberOfGoroutinesEnvVarName))
-	if err != nil {
-		return MaxNumberOfGoroutinesDefaultValue
-	}
-	return valueFromEnv
 }
 
 func GetMemoryProfilingEnabled() bool {

--- a/tap/tcp_stream_factory.go
+++ b/tap/tcp_stream_factory.go
@@ -2,7 +2,6 @@ package tap
 
 import (
 	"fmt"
-	"runtime"
 	"sync"
 	"time"
 
@@ -33,8 +32,6 @@ type tcpStreamWrapper struct {
 var streams *sync.Map = &sync.Map{} // global
 var streamId int64 = 0
 
-var maxNumberOfGoroutines int
-
 func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcp *layers.TCP, ac reassembly.AssemblerContext) reassembly.Stream {
 	rlog.Debugf("* NEW: %s %s", net, transport)
 	fsmOptions := reassembly.TCPSimpleFSMOptions{
@@ -61,11 +58,6 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcp *layers.T
 		superIdentifier: &api.SuperIdentifier{},
 	}
 	if stream.isTapTarget {
-		if runtime.NumGoroutine() > maxNumberOfGoroutines {
-			appStats.IncDroppedTcpStreams()
-			rlog.Debugf("Dropped a TCP stream because of load. Total dropped: %d Total Goroutines: %d\n", appStats.DroppedTcpStreams, runtime.NumGoroutine())
-			return stream
-		}
 		streamId++
 		stream.id = streamId
 		for i, extension := range extensions {


### PR DESCRIPTION
This PR;
- Fixes the `OOMKilled` error by calling `debug.FreeOSMemory` periodically.
- Removes `MAX_NUMBER_OF_GOROUTINES` environment variable.
- Increases the default value of `TCP_STREAM_CHANNEL_TIMEOUT_MS` environment variable's value to `10000`.