### PR TITLE
[Refactor/TRA-3692] rename test rules to traffic validation

### DIFF
--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"github.com/up9inc/mizu/cli/config"
 	"github.com/up9inc/mizu/cli/config/configStructs"
 	"github.com/up9inc/mizu/cli/logger"
@@ -65,6 +66,8 @@ func init() {
 	tapCmd.Flags().Bool(configStructs.DisableRedactionTapName, defaultTapConfig.DisableRedaction, "Disables redaction of potentially sensitive request/response headers and body values")
 	tapCmd.Flags().String(configStructs.HumanMaxEntriesDBSizeTapName, defaultTapConfig.HumanMaxEntriesDBSize, "Override the default max entries db size")
 	tapCmd.Flags().Bool(configStructs.DryRunTapName, defaultTapConfig.DryRun, "Preview of all pods matching the regex, without tapping them")
-	tapCmd.Flags().String(configStructs.EnforcePolicyFileDeprecated, defaultTapConfig.EnforcePolicyFileDeprecated, "Yaml file with policy rules - DEPRECATED")
 	tapCmd.Flags().String(configStructs.EnforcePolicyFile, defaultTapConfig.EnforcePolicyFile, "Yaml file with policy rules")
+
+	tapCmd.Flags().String(configStructs.EnforcePolicyFileDeprecated, defaultTapConfig.EnforcePolicyFileDeprecated, "Yaml file with policy rules")
+	tapCmd.Flags().MarkDeprecated(configStructs.EnforcePolicyFileDeprecated, fmt.Sprintf("Use --%s instead", configStructs.EnforcePolicyFile))
 }

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -65,5 +65,6 @@ func init() {
 	tapCmd.Flags().Bool(configStructs.DisableRedactionTapName, defaultTapConfig.DisableRedaction, "Disables redaction of potentially sensitive request/response headers and body values")
 	tapCmd.Flags().String(configStructs.HumanMaxEntriesDBSizeTapName, defaultTapConfig.HumanMaxEntriesDBSize, "Override the default max entries db size")
 	tapCmd.Flags().Bool(configStructs.DryRunTapName, defaultTapConfig.DryRun, "Preview of all pods matching the regex, without tapping them")
+	tapCmd.Flags().String(configStructs.EnforcePolicyFileDeprecated, defaultTapConfig.EnforcePolicyFileDeprecated, "Yaml file with policy rules - DEPRECATED")
 	tapCmd.Flags().String(configStructs.EnforcePolicyFile, defaultTapConfig.EnforcePolicyFile, "Yaml file with policy rules")
 }

--- a/cli/cmd/tapRunner.go
+++ b/cli/cmd/tapRunner.go
@@ -48,8 +48,14 @@ func RunMizuTap() {
 		return
 	}
 	var mizuValidationRules string
-	if config.Config.Tap.EnforcePolicyFile != "" {
-		mizuValidationRules, err = readValidationRules(config.Config.Tap.EnforcePolicyFile)
+	
+	if config.Config.Tap.EnforcePolicyFile != "" || config.Config.Tap.EnforcePolicyFileDeprecated != "" {
+		trafficValidation := config.Config.Tap.EnforcePolicyFile
+		if config.Config.Tap.EnforcePolicyFileDeprecated != "" {
+			trafficValidation = config.Config.Tap.EnforcePolicyFileDeprecated
+			logger.Log.Infof(uiUtils.Warning, fmt.Sprintf("--test-rules is DEPRECATED and will be removed on the next release. Use --traffic-validation instead"))
+		}
+		mizuValidationRules, err = readValidationRules(trafficValidation)
 		if err != nil {
 			logger.Log.Errorf(uiUtils.Error, fmt.Sprintf("Error reading policy file: %v", errormessage.FormatError(err)))
 			return

--- a/cli/cmd/tapRunner.go
+++ b/cli/cmd/tapRunner.go
@@ -47,20 +47,23 @@ func RunMizuTap() {
 		logger.Log.Errorf(uiUtils.Error, fmt.Sprintf("Error parsing regex-masking: %v", errormessage.FormatError(err)))
 		return
 	}
+
 	var mizuValidationRules string
-	
 	if config.Config.Tap.EnforcePolicyFile != "" || config.Config.Tap.EnforcePolicyFileDeprecated != "" {
-		trafficValidation := config.Config.Tap.EnforcePolicyFile
-		if config.Config.Tap.EnforcePolicyFileDeprecated != "" {
+		var trafficValidation string
+		if config.Config.Tap.EnforcePolicyFile != "" {
+			trafficValidation = config.Config.Tap.EnforcePolicyFile
+		} else {
 			trafficValidation = config.Config.Tap.EnforcePolicyFileDeprecated
-			logger.Log.Infof(uiUtils.Warning, fmt.Sprintf("--test-rules is DEPRECATED and will be removed on the next release. Use --traffic-validation instead"))
 		}
+
 		mizuValidationRules, err = readValidationRules(trafficValidation)
 		if err != nil {
 			logger.Log.Errorf(uiUtils.Error, fmt.Sprintf("Error reading policy file: %v", errormessage.FormatError(err)))
 			return
 		}
 	}
+
 	kubernetesProvider, err := kubernetes.NewProvider(config.Config.KubeConfigPath())
 	if err != nil {
 		logger.Log.Error(err)

--- a/cli/config/configStructs/tapConfig.go
+++ b/cli/config/configStructs/tapConfig.go
@@ -16,8 +16,8 @@ const (
 	DisableRedactionTapName       = "no-redact"
 	HumanMaxEntriesDBSizeTapName  = "max-entries-db-size"
 	DryRunTapName                 = "dry-run"
-	EnforcePolicyFileDeprecated   = "test-rules"
 	EnforcePolicyFile             = "traffic-validation"
+	EnforcePolicyFileDeprecated   = "test-rules"
 )
 
 type TapConfig struct {
@@ -33,8 +33,8 @@ type TapConfig struct {
 	DisableRedaction             bool      `yaml:"no-redact" default:"false"`
 	HumanMaxEntriesDBSize        string    `yaml:"max-entries-db-size" default:"200MB"`
 	DryRun                       bool      `yaml:"dry-run" default:"false"`
-	EnforcePolicyFileDeprecated  string    `yaml:"test-rules"`
 	EnforcePolicyFile            string    `yaml:"traffic-validation"`
+	EnforcePolicyFileDeprecated  string    `yaml:"test-rules"`
 	ApiServerResources           Resources `yaml:"api-server-resources"`
 	TapperResources              Resources `yaml:"tapper-resources"`
 }

--- a/cli/config/configStructs/tapConfig.go
+++ b/cli/config/configStructs/tapConfig.go
@@ -16,7 +16,8 @@ const (
 	DisableRedactionTapName       = "no-redact"
 	HumanMaxEntriesDBSizeTapName  = "max-entries-db-size"
 	DryRunTapName                 = "dry-run"
-	EnforcePolicyFile             = "test-rules"
+	EnforcePolicyFileDeprecated   = "test-rules"
+	EnforcePolicyFile             = "traffic-validation"
 )
 
 type TapConfig struct {
@@ -32,7 +33,8 @@ type TapConfig struct {
 	DisableRedaction             bool      `yaml:"no-redact" default:"false"`
 	HumanMaxEntriesDBSize        string    `yaml:"max-entries-db-size" default:"200MB"`
 	DryRun                       bool      `yaml:"dry-run" default:"false"`
-	EnforcePolicyFile            string    `yaml:"test-rules"`
+	EnforcePolicyFileDeprecated  string    `yaml:"test-rules"`
+	EnforcePolicyFile            string    `yaml:"traffic-validation"`
 	ApiServerResources           Resources `yaml:"api-server-resources"`
 	TapperResources              Resources `yaml:"tapper-resources"`
 }

--- a/docs/POLICY_RULES.md
+++ b/docs/POLICY_RULES.md
@@ -24,14 +24,14 @@ To use this feature - create simple rules file (see details below) and pass this
 
 
 ```shell
-mizu tap --test-rules rules.yaml PODNAME
+mizu tap --traffic-validation rules.yaml PODNAME
 ```
 
 
 
 ## Rules file structure
 
-The structure of the test-rules-file is:
+The structure of the traffic-validation-file is:
 
 * `name`: string, name of the rule
 * `type`: string, type of the rule, must be `json` or `header` or `latency`


### PR DESCRIPTION
Added:

- --traffic-validation on `tap cli` and inside the `config` file
- Deprecation Warning on --test-rules on CLI and config file

```bash
❯ go run mizu.go tap
Mizu will store up to 200MB of traffic, old traffic will be cleared once the limit is reached.
--test-rules is DEPRECATED and will be removed on the next release. Use --traffic-validation instead
Tapping pods in namespaces "sock-shop"
```