### PR TITLE
Omit the `RESPONSE` tab and `elapsedTime` if the `response` is empty

### DIFF
--- a/ui/src/components/EntryDetailed.tsx
+++ b/ui/src/components/EntryDetailed.tsx
@@ -41,7 +41,7 @@ const EntryTitle: React.FC<any> = ({protocol, data, bodySize, elapsedTime}) => {
         <Protocol protocol={protocol} horizontal={true}/>
         <div style={{right: "30px", position: "absolute", display: "flex"}}>
             {response.payload && <div style={{margin: "0 18px", opacity: 0.5}}>{formatSize(bodySize)}</div>}
-            <div style={{marginRight: 18, opacity: 0.5}}>{Math.round(elapsedTime)}ms</div>
+            {response.payload && <div style={{marginRight: 18, opacity: 0.5}}>{Math.round(elapsedTime)}ms</div>}
         </div>
     </div>;
 };

--- a/ui/src/components/EntryDetailed/EntryViewer.tsx
+++ b/ui/src/components/EntryDetailed/EntryViewer.tsx
@@ -57,13 +57,13 @@ const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapse
     return <div className={styles.Entry}>
         {<div className={styles.body}>
             <div className={styles.bodyHeader}>
-                <Tabs tabs={TABS} currentTab={currentTab} color={color} onChange={setCurrentTab} leftAligned/>
+                <Tabs tabs={TABS} currentTab={currentTab} color={color} response={response} onChange={setCurrentTab} leftAligned/>
                 {request?.url && <a className={styles.endpointURL} href={request.payload.url} target='_blank' rel="noreferrer">{request.payload.url}</a>}
             </div>
             {currentTab === TABS[0].tab && <React.Fragment>
                 <SectionsRepresentation data={request} color={color}/>
             </React.Fragment>}
-            {currentTab === TABS[1].tab && <React.Fragment>
+            {response && currentTab === TABS[1].tab && <React.Fragment>
                 <SectionsRepresentation data={response} color={color}/>
             </React.Fragment>}
             {currentTab === TABS[2].tab && <React.Fragment>

--- a/ui/src/components/EntryDetailed/EntryViewer.tsx
+++ b/ui/src/components/EntryDetailed/EntryViewer.tsx
@@ -54,10 +54,14 @@ const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapse
 
     const {request, response} = JSON.parse(representation);
 
+    if (!response) {
+        TABS[1]['hidden'] = true;
+    }
+
     return <div className={styles.Entry}>
         {<div className={styles.body}>
             <div className={styles.bodyHeader}>
-                <Tabs tabs={TABS} currentTab={currentTab} color={color} response={response} onChange={setCurrentTab} leftAligned/>
+                <Tabs tabs={TABS} currentTab={currentTab} color={color} onChange={setCurrentTab} leftAligned/>
                 {request?.url && <a className={styles.endpointURL} href={request.payload.url} target='_blank' rel="noreferrer">{request.payload.url}</a>}
             </div>
             {currentTab === TABS[0].tab && <React.Fragment>

--- a/ui/src/components/UI/Tabs.tsx
+++ b/ui/src/components/UI/Tabs.tsx
@@ -17,6 +17,7 @@ interface Props {
     tabs: Tab[],
     currentTab: string,
     color: string,
+    response: any,
     onChange: (string) => void,
     leftAligned?: boolean,
     dark?: boolean,
@@ -72,10 +73,13 @@ const useTabsStyles = makeStyles((theme) => ({
 }));
 
 
-const Tabs: React.FC<Props> = ({classes={}, tabs, currentTab, color, onChange, leftAligned, dark}) => {
+const Tabs: React.FC<Props> = ({classes={}, tabs, currentTab, color, response, onChange, leftAligned, dark}) => {
     const _classes = {...useTabsStyles(), ...classes};
     return <div className={`${_classes.root} ${leftAligned ? _classes.tabsAlignLeft : ''}`}>
         {tabs.filter((tab) => !tab.hidden).map(({tab, disabled, disabledMessage, highlight, badge}, index) => {
+            if (!response && index === 1) {
+                return <></>;
+            }
             const active = currentTab === tab;
             const tabLink = <span
                 key={tab}

--- a/ui/src/components/UI/Tabs.tsx
+++ b/ui/src/components/UI/Tabs.tsx
@@ -17,7 +17,6 @@ interface Props {
     tabs: Tab[],
     currentTab: string,
     color: string,
-    response: any,
     onChange: (string) => void,
     leftAligned?: boolean,
     dark?: boolean,
@@ -73,13 +72,10 @@ const useTabsStyles = makeStyles((theme) => ({
 }));
 
 
-const Tabs: React.FC<Props> = ({classes={}, tabs, currentTab, color, response, onChange, leftAligned, dark}) => {
+const Tabs: React.FC<Props> = ({classes={}, tabs, currentTab, color, onChange, leftAligned, dark}) => {
     const _classes = {...useTabsStyles(), ...classes};
     return <div className={`${_classes.root} ${leftAligned ? _classes.tabsAlignLeft : ''}`}>
         {tabs.filter((tab) => !tab.hidden).map(({tab, disabled, disabledMessage, highlight, badge}, index) => {
-            if (!response && index === 1) {
-                return <></>;
-            }
             const active = currentTab === tab;
             const tabLink = <span
                 key={tab}


### PR DESCRIPTION
This PR omits the the `RESPONSE` tab and `elapsedTime` if the `response` is empty.