### PR TITLE
Don't redact `:authority` pseudo-header field

### DIFF
--- a/tap/extensions/http/sensitive_data_cleaner.go
+++ b/tap/extensions/http/sensitive_data_cleaner.go
@@ -86,6 +86,10 @@ func getContentTypeHeaderValue(headers http.Header) string {
 }
 
 func isFieldNameSensitive(fieldName string) bool {
+	if fieldName == ":authority" {
+		return false
+	}
+
 	name := strings.ToLower(fieldName)
 	name = strings.ReplaceAll(name, "_", "")
 	name = strings.ReplaceAll(name, "-", "")


### PR DESCRIPTION
`:authority` pseudo-header field is the virtual host name of authority and it's a crucial component of address resolution in HTTP/2. So don't redact it.

References:
- https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3
- https://grpc.github.io/grpc/core/md_doc_naming.html
- https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests

From:

![Screenshot from 2021-09-22 21-50-02](https://user-images.githubusercontent.com/2502080/134405562-d486762c-bc88-4865-b4ce-3520b844bd52.png)


To:

![Screenshot from 2021-09-22 21-53-19](https://user-images.githubusercontent.com/2502080/134405584-0edbd622-8e31-4ae4-91e1-93a3b0902941.png)