### PR TITLE
Don't omit the `Latency` field in `BaseEntryDetails`

### DIFF
--- a/agent/pkg/api/main.go
+++ b/agent/pkg/api/main.go
@@ -115,7 +115,6 @@ func startReadingChannel(outputItems <-chan *tapApi.OutputChannelItem, extension
 			if err == nil {
 				rules, _ := models.RunValidationRulesState(*harEntry, mizuEntry.Service)
 				baseEntry.Rules = rules
-				baseEntry.Latency = mizuEntry.ElapsedTime
 			}
 		}
 

--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -156,7 +156,7 @@ type BaseEntryDetails struct {
 	SourcePort      string          `json:"sourcePort,omitempty"`
 	DestinationPort string          `json:"destinationPort,omitempty"`
 	IsOutgoing      bool            `json:"isOutgoing,omitempty"`
-	Latency         int64           `json:"latency,omitempty"`
+	Latency         int64           `json:"latency"`
 	Rules           ApplicableRules `json:"rules,omitempty"`
 }
 
@@ -190,6 +190,7 @@ func (bed *BaseEntryDetails) UnmarshalData(entry *MizuEntry) error {
 	bed.Timestamp = entry.Timestamp
 	bed.RequestSenderIp = entry.RequestSenderIp
 	bed.IsOutgoing = entry.IsOutgoing
+	bed.Latency = entry.ElapsedTime
 	return nil
 }
 

--- a/tap/extensions/amqp/main.go
+++ b/tap/extensions/amqp/main.go
@@ -312,7 +312,7 @@ func (d dissecting) Summarize(entry *api.MizuEntry) *api.BaseEntryDetails {
 		SourcePort:      entry.SourcePort,
 		DestinationPort: entry.DestinationPort,
 		IsOutgoing:      entry.IsOutgoing,
-		Latency:         0,
+		Latency:         entry.ElapsedTime,
 		Rules: api.ApplicableRules{
 			Latency: 0,
 			Status:  false,

--- a/tap/extensions/http/main.go
+++ b/tap/extensions/http/main.go
@@ -223,7 +223,7 @@ func (d dissecting) Summarize(entry *api.MizuEntry) *api.BaseEntryDetails {
 		SourcePort:      entry.SourcePort,
 		DestinationPort: entry.DestinationPort,
 		IsOutgoing:      entry.IsOutgoing,
-		Latency:         0,
+		Latency:         entry.ElapsedTime,
 		Rules: api.ApplicableRules{
 			Latency: 0,
 			Status:  false,

--- a/tap/extensions/kafka/main.go
+++ b/tap/extensions/kafka/main.go
@@ -186,7 +186,7 @@ func (d dissecting) Summarize(entry *api.MizuEntry) *api.BaseEntryDetails {
 		SourcePort:      entry.SourcePort,
 		DestinationPort: entry.DestinationPort,
 		IsOutgoing:      entry.IsOutgoing,
-		Latency:         0,
+		Latency:         entry.ElapsedTime,
 		Rules: api.ApplicableRules{
 			Latency: 0,
 			Status:  false,


### PR DESCRIPTION
Since the `Latency` field was being omitted, the boolean expression below was becoming `false`:

https://github.com/up9inc/mizu/blob/43f44af0dd2f376bf508551b36bb800787a160c4/ui/src/components/EntryListItem/EntryListItem.tsx#L71-L77

The **rules.yaml** file below reproduces it:

```yaml
rules:
- name: latency-test
  type: latency
  latency: 1
  service: ".*"
  path: "/*"
```

Before:

![Screenshot from 2021-09-23 14-21-26](https://user-images.githubusercontent.com/2502080/134498887-430a6172-2531-42f5-8703-e353cce4ada1.png)

After:

![Screenshot from 2021-09-23 14-25-51](https://user-images.githubusercontent.com/2502080/134499036-709bd49d-0bb9-42af-a1e9-8a6cd27a967f.png)
