### PR TITLE
Omit the `RULES` tab if the policy rules feature is inactive

### DIFF
--- a/agent/pkg/api/main.go
+++ b/agent/pkg/api/main.go
@@ -113,7 +113,7 @@ func startReadingChannel(outputItems <-chan *tapApi.OutputChannelItem, extension
 			json.Unmarshal([]byte(mizuEntry.Entry), &pair)
 			harEntry, err := utils.NewEntry(&pair)
 			if err == nil {
-				rules, _ := models.RunValidationRulesState(*harEntry, mizuEntry.Service)
+				rules, _, _ := models.RunValidationRulesState(*harEntry, mizuEntry.Service)
 				baseEntry.Rules = rules
 			}
 		}

--- a/agent/pkg/controllers/entries_controller.go
+++ b/agent/pkg/controllers/entries_controller.go
@@ -147,6 +147,7 @@ func GetEntry(c *gin.Context) {
 		var pair tapApi.RequestResponsePair
 		json.Unmarshal([]byte(entryData.Entry), &pair)
 		harEntry, _ := utils.NewEntry(&pair)
+		// TODO: here
 		_, rulesMatched := models.RunValidationRulesState(*harEntry, entryData.Service)
 		inrec, _ := json.Marshal(rulesMatched)
 		json.Unmarshal(inrec, &rules)

--- a/agent/pkg/controllers/entries_controller.go
+++ b/agent/pkg/controllers/entries_controller.go
@@ -143,12 +143,13 @@ func GetEntry(c *gin.Context) {
 	protocol, representation, bodySize, _ := extension.Dissector.Represent(&entryData)
 
 	var rules []map[string]interface{}
+	var isRulesEnabled bool
 	if entryData.ProtocolName == "http" {
 		var pair tapApi.RequestResponsePair
 		json.Unmarshal([]byte(entryData.Entry), &pair)
 		harEntry, _ := utils.NewEntry(&pair)
-		// TODO: here
-		_, rulesMatched := models.RunValidationRulesState(*harEntry, entryData.Service)
+		_, rulesMatched, _isRulesEnabled := models.RunValidationRulesState(*harEntry, entryData.Service)
+		isRulesEnabled = _isRulesEnabled
 		inrec, _ := json.Marshal(rulesMatched)
 		json.Unmarshal(inrec, &rules)
 	}
@@ -159,6 +160,7 @@ func GetEntry(c *gin.Context) {
 		BodySize:       bodySize,
 		Data:           entryData,
 		Rules:          rules,
+		IsRulesEnabled: isRulesEnabled,
 	})
 }
 

--- a/agent/pkg/models/models.go
+++ b/agent/pkg/models/models.go
@@ -97,8 +97,8 @@ type ExtendedCreator struct {
 	Source *string `json:"_source"`
 }
 
-func RunValidationRulesState(harEntry har.Entry, service string) (tapApi.ApplicableRules, []rules.RulesMatched) {
-	resultPolicyToSend := rules.MatchRequestPolicy(harEntry, service)
+func RunValidationRulesState(harEntry har.Entry, service string) (tapApi.ApplicableRules, []rules.RulesMatched, bool) {
+	resultPolicyToSend, isEnabled := rules.MatchRequestPolicy(harEntry, service)
 	statusPolicyToSend, latency, numberOfRules := rules.PassedValidationRules(resultPolicyToSend)
-	return tapApi.ApplicableRules{Status: statusPolicyToSend, Latency: latency, NumberOfRules: numberOfRules}, resultPolicyToSend
+	return tapApi.ApplicableRules{Status: statusPolicyToSend, Latency: latency, NumberOfRules: numberOfRules}, resultPolicyToSend, isEnabled
 }

--- a/agent/pkg/rules/rulesHTTP.go
+++ b/agent/pkg/rules/rulesHTTP.go
@@ -4,10 +4,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/romana/rlog"
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/romana/rlog"
 
 	"github.com/google/martian/har"
 	"github.com/up9inc/mizu/shared"
@@ -43,9 +44,11 @@ func ValidateService(serviceFromRule string, service string) bool {
 	return true
 }
 
-func MatchRequestPolicy(harEntry har.Entry, service string) []RulesMatched {
-	enforcePolicy, _ := shared.DecodeEnforcePolicy(fmt.Sprintf("%s/%s", shared.RulePolicyPath, shared.RulePolicyFileName))
-	var resultPolicyToSend []RulesMatched
+func MatchRequestPolicy(harEntry har.Entry, service string) (resultPolicyToSend []RulesMatched, isEnabled bool) {
+	enforcePolicy, err := shared.DecodeEnforcePolicy(fmt.Sprintf("%s/%s", shared.RulePolicyPath, shared.RulePolicyFileName))
+	if err == nil {
+		isEnabled = true
+	}
 	for _, rule := range enforcePolicy.Rules {
 		if !ValidatePath(rule.Path, harEntry.Request.URL) || !ValidateService(rule.Service, service) {
 			continue
@@ -93,7 +96,7 @@ func MatchRequestPolicy(harEntry har.Entry, service string) []RulesMatched {
 			resultPolicyToSend = appendRulesMatched(resultPolicyToSend, true, rule)
 		}
 	}
-	return resultPolicyToSend
+	return
 }
 
 func PassedValidationRules(rulesMatched []RulesMatched) (bool, int64, int) {

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -447,7 +447,7 @@ func (provider *Provider) RemoveDaemonSet(ctx context.Context, namespace string,
 func (provider *Provider) handleRemovalError(err error) error {
 	// Ignore NotFound - There is nothing to delete.
 	// Ignore Forbidden - Assume that a user could not have created the resource in the first place.
-	if k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err){
+	if k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
 		return nil
 	}
 

--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -138,6 +138,7 @@ type MizuEntryWrapper struct {
 	BodySize       int64                    `json:"bodySize"`
 	Data           MizuEntry                `json:"data"`
 	Rules          []map[string]interface{} `json:"rulesMatched,omitempty"`
+	IsRulesEnabled bool                     `json:"isRulesEnabled"`
 }
 
 type BaseEntryDetails struct {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -91,7 +91,7 @@ const App = () => {
                 </table>
 
             </span>
-      
+
     return (
         <div className="mizuApp">
             <div className="header">

--- a/ui/src/components/EntryDetailed.tsx
+++ b/ui/src/components/EntryDetailed.tsx
@@ -72,7 +72,7 @@ export const EntryDetailed: React.FC<EntryDetailedProps> = ({entryData}) => {
         />
         {entryData.data && <EntrySummary data={entryData.data}/>}
         <>
-            {entryData.data && <EntryViewer representation={entryData.representation} rulesMatched={entryData.rulesMatched} elapsedTime={entryData.data.elapsedTime} color={entryData.protocol.backgroundColor}/>}
+            {entryData.data && <EntryViewer representation={entryData.representation} isRulesEnabled={entryData.isRulesEnabled} rulesMatched={entryData.rulesMatched} elapsedTime={entryData.data.elapsedTime} color={entryData.protocol.backgroundColor}/>}
         </>
     </>
 };

--- a/ui/src/components/EntryDetailed.tsx
+++ b/ui/src/components/EntryDetailed.tsx
@@ -62,6 +62,7 @@ const EntrySummary: React.FC<any> = ({data}) => {
 };
 
 export const EntryDetailed: React.FC<EntryDetailedProps> = ({entryData}) => {
+    console.log("entryData.rulesMatched:", entryData.rulesMatched)
     return <>
         <EntryTitle
             protocol={entryData.protocol}

--- a/ui/src/components/EntryDetailed.tsx
+++ b/ui/src/components/EntryDetailed.tsx
@@ -62,7 +62,6 @@ const EntrySummary: React.FC<any> = ({data}) => {
 };
 
 export const EntryDetailed: React.FC<EntryDetailedProps> = ({entryData}) => {
-    console.log("entryData.rulesMatched:", entryData.rulesMatched)
     return <>
         <EntryTitle
             protocol={entryData.protocol}

--- a/ui/src/components/EntryDetailed/EntrySections.tsx
+++ b/ui/src/components/EntryDetailed/EntrySections.tsx
@@ -153,10 +153,8 @@ export const EntryTableSection: React.FC<EntrySectionProps> = ({title, color, ar
 
 
 interface EntryPolicySectionProps {
-    service: string,
     title: string,
     color: string,
-    response: any,
     latency?: number,
     arrayToIterate: any[],
 }
@@ -200,7 +198,7 @@ export const EntryPolicySectionContainer: React.FC<EntryPolicySectionContainerPr
     </CollapsibleContainer>
 }
 
-export const EntryTablePolicySection: React.FC<EntryPolicySectionProps> = ({service, title, color, response, latency, arrayToIterate}) => {
+export const EntryTablePolicySection: React.FC<EntryPolicySectionProps> = ({title, color, latency, arrayToIterate}) => {
     return <React.Fragment>
         {
             arrayToIterate && arrayToIterate.length > 0 ?

--- a/ui/src/components/EntryDetailed/EntryViewer.tsx
+++ b/ui/src/components/EntryDetailed/EntryViewer.tsx
@@ -33,8 +33,8 @@ const SectionsRepresentation: React.FC<any> = ({data, color}) => {
     return <>{sections}</>;
 }
 
-const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapsedTime, color}) => {
-    const TABS = [
+const AutoRepresentation: React.FC<any> = ({representation, isRulesEnabled, rulesMatched, elapsedTime, color}) => {
+    var TABS = [
         {
             tab: 'request'
         },
@@ -58,9 +58,9 @@ const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapse
         TABS[1]['hidden'] = true;
     }
 
-    // if (!rulesMatched) {
-    //     TABS[2]['hidden'] = true
-    // }
+    if (!isRulesEnabled) {
+        TABS.pop()
+    }
 
     return <div className={styles.Entry}>
         {<div className={styles.body}>
@@ -74,7 +74,7 @@ const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapse
             {response && currentTab === TABS[1].tab && <React.Fragment>
                 <SectionsRepresentation data={response} color={color}/>
             </React.Fragment>}
-            {currentTab === TABS[2].tab && <React.Fragment>
+            {TABS.length > 2 && currentTab === TABS[2].tab && <React.Fragment>
                 <EntryTablePolicySection title={'Rule'} color={color} latency={elapsedTime} arrayToIterate={rulesMatched ? rulesMatched : []}/>
             </React.Fragment>}
         </div>}
@@ -83,13 +83,14 @@ const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapse
 
 interface Props {
     representation: any;
+    isRulesEnabled: boolean;
     rulesMatched: any;
     color: string;
     elapsedTime: number;
 }
 
-const EntryViewer: React.FC<Props> = ({representation, rulesMatched, elapsedTime, color}) => {
-    return <AutoRepresentation representation={representation} rulesMatched={rulesMatched} elapsedTime={elapsedTime} color={color}/>
+const EntryViewer: React.FC<Props> = ({representation, isRulesEnabled, rulesMatched, elapsedTime, color}) => {
+    return <AutoRepresentation representation={representation} isRulesEnabled={isRulesEnabled} rulesMatched={rulesMatched} elapsedTime={elapsedTime} color={color}/>
 };
 
 export default EntryViewer;

--- a/ui/src/components/EntryDetailed/EntryViewer.tsx
+++ b/ui/src/components/EntryDetailed/EntryViewer.tsx
@@ -54,6 +54,10 @@ const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapse
 
     const {request, response} = JSON.parse(representation);
 
+    // if (!rulesMatched) {
+    //     TABS[2]['hidden'] = true
+    // }
+
     return <div className={styles.Entry}>
         {<div className={styles.body}>
             <div className={styles.bodyHeader}>
@@ -67,7 +71,7 @@ const AutoRepresentation: React.FC<any> = ({representation, rulesMatched, elapse
                 <SectionsRepresentation data={response} color={color}/>
             </React.Fragment>}
             {currentTab === TABS[2].tab && <React.Fragment>
-                <EntryTablePolicySection service={representation.service} title={'Rule'} color={color} latency={elapsedTime} response={response} arrayToIterate={rulesMatched ? rulesMatched : []}/>
+                <EntryTablePolicySection title={'Rule'} color={color} latency={elapsedTime} arrayToIterate={rulesMatched ? rulesMatched : []}/>
             </React.Fragment>}
         </div>}
     </div>;


### PR DESCRIPTION
This PR omits the `RULES` tab if the policy rules feature is inactive.

`--traffic-validation-file` option is **not** supplied:

![Screenshot from 2021-09-24 14-42-16](https://user-images.githubusercontent.com/2502080/134668936-16662369-e412-4230-af0b-e2766c4c7195.png)

`--traffic-validation-file` option is supplied:

![Screenshot from 2021-09-24 14-42-52](https://user-images.githubusercontent.com/2502080/134668944-b6dcc44d-8b88-4887-9670-20ea6218fc74.png)

![Screenshot from 2021-09-24 14-42-57](https://user-images.githubusercontent.com/2502080/134668949-c877d63c-2705-480d-bdd8-fcc2d6f9ab2b.png)

![Screenshot from 2021-09-24 20-13-03](https://user-images.githubusercontent.com/2502080/134714889-665cd303-8ad1-4b73-a9bb-56bc5739481b.png)

![Screenshot from 2021-09-24 20-14-59](https://user-images.githubusercontent.com/2502080/134715033-927c755d-1f51-4311-94a0-ef140d1210ca.png)