### PR TITLE
Fix the typo in `protocolAbbreviation` field of `MizuEntry`

### DIFF
--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -106,7 +106,7 @@ type MizuEntry struct {
 	UpdatedAt               time.Time
 	ProtocolName            string `json:"protocolName" gorm:"column:protocolName"`
 	ProtocolLongName        string `json:"protocolLongName" gorm:"column:protocolLongName"`
-	ProtocolAbbreviation    string `json:"protocolAbbreviation" gorm:"column:protocolVersion"`
+	ProtocolAbbreviation    string `json:"protocolAbbreviation" gorm:"column:protocolAbbreviation"`
 	ProtocolVersion         string `json:"protocolVersion" gorm:"column:protocolVersion"`
 	ProtocolBackgroundColor string `json:"protocolBackgroundColor" gorm:"column:protocolBackgroundColor"`
 	ProtocolForegroundColor string `json:"protocolForegroundColor" gorm:"column:protocolForegroundColor"`


### PR DESCRIPTION
This PR fixes a bug that's introduced by [this line](https://github.com/up9inc/mizu/commit/616eccb2cfb13bf0259fad1b0d00afd0f53adc35#diff-06c31b5369dee97f15b8108f8d13c4283d4e056e340b5762e195f4957924e755R107) which causes the right-pane to look like HTTP/1.1 while it's HTTP/2.

Before:

![Screenshot from 2021-09-28 04-01-54](https://user-images.githubusercontent.com/2502080/135007160-0ce81820-2a1d-48dd-8a92-0a7854e99a39.png)

After:

![Screenshot from 2021-09-28 04-23-53](https://user-images.githubusercontent.com/2502080/135007194-82946795-0417-4004-a2ae-3a766180fcd4.png)
