### PR TITLE
Fix a `500` error caused by an interface conversion in Redis

### DIFF
--- a/tap/extensions/redis/helpers.go
+++ b/tap/extensions/redis/helpers.go
@@ -24,27 +24,27 @@ type RedisWrapper struct {
 	Details interface{} `json:"details"`
 }
 
-func representGeneric(generic map[string]string) (representation []interface{}) {
+func representGeneric(generic map[string]interface{}) (representation []interface{}) {
 	details, _ := json.Marshal([]map[string]string{
 		{
 			"name":  "Type",
-			"value": generic["type"],
+			"value": generic["type"].(string),
 		},
 		{
 			"name":  "Command",
-			"value": generic["command"],
+			"value": generic["command"].(string),
 		},
 		{
 			"name":  "Key",
-			"value": generic["key"],
+			"value": generic["key"].(string),
 		},
 		{
 			"name":  "Value",
-			"value": generic["value"],
+			"value": generic["value"].(string),
 		},
 		{
 			"name":  "Keyword",
-			"value": generic["keyword"],
+			"value": generic["keyword"].(string),
 		},
 	})
 	representation = append(representation, map[string]string{

--- a/tap/extensions/redis/main.go
+++ b/tap/extensions/redis/main.go
@@ -141,8 +141,8 @@ func (d dissecting) Represent(entry *api.MizuEntry) (p api.Protocol, object []by
 	representation := make(map[string]interface{}, 0)
 	request := root["request"].(map[string]interface{})["payload"].(map[string]interface{})
 	response := root["response"].(map[string]interface{})["payload"].(map[string]interface{})
-	reqDetails := request["details"].(map[string]string)
-	resDetails := response["details"].(map[string]string)
+	reqDetails := request["details"].(map[string]interface{})
+	resDetails := response["details"].(map[string]interface{})
 	repRequest := representGeneric(reqDetails)
 	repResponse := representGeneric(resDetails)
 	representation["request"] = repRequest


### PR DESCRIPTION
Fix a server-side error:
```text
[GIN] 2021/09/28 - 15:55:37 | 500 |  295.725921ms |       127.0.0.1 | GET      "/api/entries/61533af99122c03b8b8345e5"


2021/09/28 15:56:07 [Recovery] 2021/09/28 - 15:56:07 panic recovered:
interface conversion: interface {} is map[string]interface {}, not map[string]string
/usr/local/go/src/runtime/iface.go:261 (0x7f8d79a803f7)
/app/tap/extensions/redis/main.go:144 (0x7f8d79b95364)
/app/agent-build/pkg/controllers/entries_controller.go:143 (0x1fe2ad9)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x1fe75e2)
/app/agent-build/main.go:203 (0x1fe75c9)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x1fe70db)
/app/agent-build/main.go:187 (0x1fe70c2)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x11a4f79)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 (0x11a4f60)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x11a4053)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/logger.go:241 (0x11a4012)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 (0x119a289)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 (0x119a26f)
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 (0x1199d5b)
/usr/local/go/src/net/http/server.go:2867 (0xeb50e2)
/usr/local/go/src/net/http/server.go:1932 (0xeb050c)
/usr/local/go/src/runtime/asm_amd64.s:1371 (0xbeed00)
```

caused by the change below:

- https://github.com/up9inc/mizu/pull/290#discussion_r714578515
- https://github.com/up9inc/mizu/pull/290/commits/3c070b4bc0c821a353ef063343eb5b6afee64162

(simply reverts it)

It's not in the latest release `0.14.0` but rather in the `develop` branch.