### PR TITLE
Add readiness and liveness probes to API server

### DIFF
--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -193,10 +193,7 @@ func (provider *Provider) CreateMizuApiServerPod(ctx context.Context, opts *ApiS
 		command = append(command, "--namespace", opts.Namespace)
 	}
 
-	port := intstr.IntOrString{
-		Type:   intstr.Int,
-		IntVal: 8899,
-	}
+	port := intstr.FromInt(8899)
 
 	pod := &core.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -193,6 +193,11 @@ func (provider *Provider) CreateMizuApiServerPod(ctx context.Context, opts *ApiS
 		command = append(command, "--namespace", opts.Namespace)
 	}
 
+	port := intstr.IntOrString{
+		Type:   intstr.Int,
+		IntVal: 8899,
+	}
+
 	pod := &core.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      opts.PodName,
@@ -231,6 +236,25 @@ func (provider *Provider) CreateMizuApiServerPod(ctx context.Context, opts *ApiS
 							"cpu":    cpuRequests,
 							"memory": memRequests,
 						},
+					},
+					ReadinessProbe: &core.Probe{
+						Handler: core.Handler{
+							TCPSocket: &core.TCPSocketAction{
+								Port: port,
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       10,
+					},
+					LivenessProbe: &core.Probe{
+						Handler: core.Handler{
+							HTTPGet: &core.HTTPGetAction{
+								Path: "/echo",
+								Port: port,
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       10,
 					},
 				},
 			},


### PR DESCRIPTION
Related to https://github.com/up9inc/mizu/pull/309

Prevents WebSocket connection errors from tappers to the API server by adding readiness and liveness probes to API server.