### PR TITLE
Bring back the lines that didn't mean to be removed

### DIFF
--- a/tap/extensions/http/handlers.go
+++ b/tap/extensions/http/handlers.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/up9inc/mizu/tap/api"
@@ -84,6 +87,9 @@ func handleHTTP1ClientStream(b *bufio.Reader, tcpID *api.TcpID, counterPair *api
 	}
 	counterPair.Request++
 
+	body, err := ioutil.ReadAll(req.Body)
+	req.Body = io.NopCloser(bytes.NewBuffer(body)) // rewind
+
 	ident := fmt.Sprintf(
 		"%s->%s %s->%s %d",
 		tcpID.SrcIP,
@@ -112,6 +118,9 @@ func handleHTTP1ServerStream(b *bufio.Reader, tcpID *api.TcpID, counterPair *api
 		return err
 	}
 	counterPair.Response++
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body = io.NopCloser(bytes.NewBuffer(body)) // rewind
 
 	ident := fmt.Sprintf(
 		"%s->%s %s->%s %d",


### PR DESCRIPTION
Introduced by https://github.com/up9inc/mizu/commit/29ba963c48b5bdb82fbd20b71cbb39d591c7b9af (the latest commit)

`kubectl logs --follow mizu-tapper-daemon-set-wf7n9 -n mizu`

```
2021-10-19T13:06:41.387Z INFO ▶ 1 main.go:138 loadExtensions ▶ Loading extension: amqp.so
2021/10/19 13:06:41 Initializing AMQP extension...
2021-10-19T13:06:41.393Z INFO ▶ 1 main.go:138 loadExtensions ▶ Loading extension: http.so
2021/10/19 13:06:41 Initializing HTTP extension...
2021-10-19T13:06:41.398Z INFO ▶ 1 main.go:138 loadExtensions ▶ Loading extension: kafka.so
2021/10/19 13:06:41 Initializing Kafka extension...
2021-10-19T13:06:41.403Z INFO ▶ 1 main.go:138 loadExtensions ▶ Loading extension: redis.so
2021/10/19 13:06:41 Initializing Redis extension...
2021-10-19T13:06:41.411Z INFO ▶ 1 main.go:163 loadExtensions ▶ Extension Properties: &{Protocol:0x7f4c1338b1a0 Path:/app/extensions/http.so Plug:0xc00074cbd0 Dissector:0x7f4c133ca680 MatcherMap:0xc00074cc30}
2021-10-19T13:06:41.411Z INFO ▶ 1 main.go:163 loadExtensions ▶ Extension Properties: &{Protocol:0x7f4c13a7cf40 Path:/app/extensions/amqp.so Plug:0xc00074c990 Dissector:0x7f4c13ab2160 MatcherMap:<nil>}
2021-10-19T13:06:41.411Z INFO ▶ 1 main.go:163 loadExtensions ▶ Extension Properties: &{Protocol:0x7f4c12bc6d00 Path:/app/extensions/kafka.so Plug:0xc00074cd50 Dissector:0x7f4c12bfcae0 MatcherMap:0xc00074ce40}
2021-10-19T13:06:41.411Z INFO ▶ 1 main.go:163 loadExtensions ▶ Extension Properties: &{Protocol:0x7f4c124b7d40 Path:/app/extensions/redis.so Plug:0xc00074cf60 Dissector:0x7f4c124ede80 MatcherMap:0xc00074cf90}
2021-10-19T13:06:41.411Z INFO ▶ 1 main.go:69 main ▶ Starting tapper, websocket address: ws://mizu-api-server.mizu.svc.cluster.local/wsTapper
2021-10-19T13:06:41.411Z INFO ▶ 1 main.go:77 main ▶ Filtering for the following authorities: [172.17.0.12 172.17.0.5 172.17.0.8 172.17.0.10 172.17.0.2 172.17.0.16 172.17.0.4 172.17.0.9 172.17.0.13 172.17.0.6 172.17.0.3 172.17.0.14 172.17.0.15 172.17.0.11]
2021-10-19T13:06:41.413Z INFO ▶ 1 main.go:90 main ▶ Connected successfully to websocket ws://mizu-api-server.mizu.svc.cluster.local/wsTapper
2021-10-19T13:06:41.446Z INFO ▶ 1 passive_tapper.go:327 startPassiveTapper ▶ Starting to read packets
2021-10-19T13:06:41.446Z INFO ▶ 1 passive_tapper.go:344 startPassiveTapper ▶ Assembler options: maxBufferedPagesTotal=5000, maxBufferedPagesPerConnection=5000
panic: runtime error: slice bounds out of range [:5544] with capacity 4096

goroutine 559 [running]:
bufio.(*Reader).Read(0xc00066a5a0, 0xc0004aa200, 0x200, 0x200, 0xc, 0x2230f40, 0x1)
	/usr/local/go/src/bufio/bufio.go:238 +0x3ba
io.(*LimitedReader).Read(0xc0007e8678, 0xc0004aa200, 0x200, 0x200, 0xc00029ea10, 0x2, 0xffffffffffffffff)
	/usr/local/go/src/io/io.go:473 +0x63
net/http.(*body).readLocked(0xc00011e040, 0xc0004aa200, 0x200, 0x200, 0x0, 0xc00001cb70, 0x7f4c12ede86e)
	/usr/local/go/src/net/http/transfer.go:842 +0x5f
net/http.(*body).Read(0xc00011e040, 0xc0004aa200, 0x200, 0x200, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transfer.go:834 +0xf9
io.ReadAll(0x7f4c11acd498, 0xc00011e040, 0xc00011e040, 0x7f4c11acd498, 0xc00011e040, 0xc000734f00, 0xc0004aa000)
	/usr/local/go/src/io/io.go:633 +0xdf
io/ioutil.ReadAll(...)
	/usr/local/go/src/io/ioutil/ioutil.go:27
github.com/up9inc/mizu/tap/extensions/http.filterResponseBody(0xc00046e240, 0xc000734f00)
	/app/tap/extensions/http/sensitive_data_cleaner.go:78 +0x9f
github.com/up9inc/mizu/tap/extensions/http.FilterSensitiveData(0xc0000e2370, 0xc000734f00)
	/app/tap/extensions/http/sensitive_data_cleaner.go:59 +0xfd
github.com/up9inc/mizu/tap/extensions/http.filterAndEmit(0xc0000e2370, 0x2793880, 0xc000ca0070, 0xc000734f00)
	/app/tap/extensions/http/handlers.go:17 +0x88
github.com/up9inc/mizu/tap/extensions/http.handleHTTP1ClientStream(0xc00066a480, 0xc000a243c0, 0xc00038c950, 0xc00000e330, 0x2793880, 0xc000ca0070, 0xc000734f00, 0x0, 0x0)
	/app/tap/extensions/http/handlers.go:104 +0x335
github.com/up9inc/mizu/tap/extensions/http.dissecting.Dissect(0x0, 0x0, 0xc00066a480, 0xc000598001, 0xc000a243c0, 0xc00038c950, 0xc00000e330, 0xc000208480, 0x2793880, 0xc000ca0070, ...)
	/app/tap/extensions/http/main.go:86 +0x196
github.com/up9inc/mizu/tap.(*tcpReader).run(0xc000a52120, 0xc00074c840)
	/app/tap/tcp_reader.go:110 +0x1c8
created by github.com/up9inc/mizu/tap.(*tcpStreamFactory).New
	/app/tap/tcp_stream_factory.go:112 +0x1930
```
