### PR TITLE
Add k8s version requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Think TCPDump and Chrome Dev Tools combined.
 - No installation or code instrumentation
 - Works completely on premises
 
+## Requirements
+
+A Kubernetes Server version of 1.16.0 is required.
+
 ## Download
 
 Download Mizu for your platform and operating system


### PR DESCRIPTION
A version lower than 1.16.0 fails with the error message: `Error updating tappers: 415: Unsupported Media Type`.
In response to https://github.com/up9inc/mizu/issues/361.