### PR TITLE
Set a default value for `SEM_VER` build-time variable in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN go list -f '{{.Path}}@{{.Version}}' -m all | sed 1d | grep -e 'go-cache' -e 
 ARG COMMIT_HASH
 ARG GIT_BRANCH
 ARG BUILD_TIMESTAMP
-ARG SEM_VER
+ARG SEM_VER=0.0.0
 
 # Copy and build agent code
 COPY shared ../shared

--- a/cli/apiserver/provider.go
+++ b/cli/apiserver/provider.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/up9inc/mizu/shared/kubernetes"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/up9inc/mizu/shared/kubernetes"
 
 	"github.com/up9inc/mizu/cli/config"
 	"github.com/up9inc/mizu/shared"
@@ -28,7 +29,7 @@ const DefaultTimeout = 5 * time.Second
 
 func NewProvider(url string, retries int, timeout time.Duration) *Provider {
 	return &Provider{
-		url: url,
+		url:     url,
 		retries: config.GetIntEnvConfig(config.ApiServerRetries, retries),
 		client: &http.Client{
 			Timeout: timeout,

--- a/cli/mizu/version/versionCheck.go
+++ b/cli/mizu/version/versionCheck.go
@@ -24,6 +24,11 @@ func CheckVersionCompatibility(apiServerProvider *apiserver.Provider) (bool, err
 		return false, err
 	}
 
+	if !semver.SemVersion(apiSemVer).IsValid() {
+		logger.Log.Errorf(uiUtils.Red, fmt.Sprintf("api version (%s) is not a valid SemVer", apiSemVer))
+		return false, nil
+	}
+
 	if semver.SemVersion(apiSemVer).Major() == semver.SemVersion(mizu.SemVer).Major() &&
 		semver.SemVersion(apiSemVer).Minor() == semver.SemVersion(mizu.SemVer).Minor() {
 		return true, nil

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -28,7 +28,7 @@ RUN go list -f '{{.Path}}@{{.Version}}' -m all | sed 1d | grep -e 'go-cache' -e 
 ARG COMMIT_HASH
 ARG GIT_BRANCH
 ARG BUILD_TIMESTAMP
-ARG SEM_VER
+ARG SEM_VER=0.0.0
 
 # Copy and build agent code
 COPY shared ../shared


### PR DESCRIPTION
This PR;

Sets a default value for `SEM_VER` build-time variable in `Dockerfile`

Also fixes a runtime error that happens when the API server's version is not a valid SemVer:

```
$ ./cli/bin/mizu__ view                                                                                                                                                                                       ok  10s  17:52:37 
Establishing connection to k8s cluster...
Mizu is available at http://localhost:8899/mizu
Update available! 0.0.0 -> 0.18.0 (curl -Lo mizu https://github.com/up9inc/mizu/releases/download/0.18.0/mizu_linux_amd64 && chmod 755 mizu)
Unhandled panic: runtime error: index out of range [0] with length 0
 stack: goroutine 1 [running]:
runtime/debug.Stack(0xc00011f558, 0x21a8180, 0xc0001544b0)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9f
github.com/up9inc/mizu/cli/cmd/goUtils.HandleExcWrapper.func1()
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/goUtils/funcWrappers.go:13 +0x5b
panic(0x21a8180, 0xc0001544b0)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/up9inc/mizu/shared/semver.SemVersion.Breakdown(0x0, 0x0, 0x0, 0x0, 0x0, 0xc00061b828, 0x1d8fd25, 0xc00049e2c0)
	/home/mertyildiran/Documents/up9/mizu/shared/semver/semver.go:20 +0xe5
github.com/up9inc/mizu/shared/semver.SemVersion.Major(...)
	/home/mertyildiran/Documents/up9/mizu/shared/semver/semver.go:24
github.com/up9inc/mizu/cli/mizu/version.CheckVersionCompatibility(0xc00061b958, 0x1a, 0xc000612500, 0xc000612520)
	/home/mertyildiran/Documents/up9/mizu/cli/mizu/version/versionCheck.go:27 +0x7e
github.com/up9inc/mizu/cli/cmd.runMizuView()
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/viewRunner.go:63 +0x456
github.com/up9inc/mizu/cli/cmd.glob..func8(0x2fbb780, 0x306c738, 0x0, 0x0, 0x0, 0x0)
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/view.go:16 +0x85
github.com/spf13/cobra.(*Command).execute(0x2fbb780, 0x306c738, 0x0, 0x0, 0x2fbb780, 0x306c738)
	/home/mertyildiran/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x2fbb000, 0x237cac8, 0xc00010f140, 0x0)
	/home/mertyildiran/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/mertyildiran/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/up9inc/mizu/cli/cmd.Execute()
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/root.go:60 +0xb9
reflect.Value.call(0x1f7d9c0, 0x237ca18, 0x13, 0x22b1932, 0x4, 0x306c738, 0x0, 0x0, 0xc000193e88, 0xbd35ac, ...)
	/usr/local/go/src/reflect/value.go:476 +0x8e7
reflect.Value.Call(0x1f7d9c0, 0x237ca18, 0x13, 0x306c738, 0x0, 0x0, 0xbc1745, 0xc000078710, 0xbc662a)
	/usr/local/go/src/reflect/value.go:337 +0xb9
github.com/up9inc/mizu/cli/cmd/goUtils.HandleExcWrapper(0x1f7d9c0, 0x237ca18, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/goUtils/funcWrappers.go:25 +0x24f
main.main()
	/home/mertyildiran/Documents/up9/mizu/cli/mizu.go:9 +0x4a
```