### PR TITLE
Ignore `SNYK-JS-JSONSCHEMA-1920922`

### DIFF
--- a/ui/.snyk
+++ b/ui/.snyk
@@ -133,3 +133,6 @@ ignore:
   SNYK-JS-WS-1296835:
     - '*':
         reason: Non given
+  SNYK-JS-JSONSCHEMA-1920922:
+    - '*':
+        reason: Non given


### PR DESCRIPTION
Dependency tree:
`node-sass@5.0.0 > node-gyp@7.1.2 > request@2.88.2 > http-signature@1.2.0 > jsprim@1.4.1 > json-schema@0.2.3`

`node-sass` should fix it first.