### PR TITLE
Return `404` instead of `500` if the entry could not be found and display a toast message

### DIFF
--- a/agent/pkg/controllers/entries_controller.go
+++ b/agent/pkg/controllers/entries_controller.go
@@ -25,7 +25,12 @@ func Error(c *gin.Context, err error) bool {
 	if err != nil {
 		logger.Log.Errorf("Error getting entry: %v", err)
 		c.Error(err)
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": true, "msg": err.Error()})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":     true,
+			"type":      "error",
+			"autoClose": "5000",
+			"msg":       err.Error(),
+		})
 		return true // signal that there was an error and the caller should return
 	}
 	return false // no error, can continue
@@ -39,7 +44,13 @@ func GetEntry(c *gin.Context) {
 		return // exit
 	}
 	err = json.Unmarshal(bytes, &entry)
-	if Error(c, err) {
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":     true,
+			"type":      "error",
+			"autoClose": "5000",
+			"msg":       string(bytes),
+		})
 		return // exit
 	}
 

--- a/ui/src/components/TrafficPage.tsx
+++ b/ui/src/components/TrafficPage.tsx
@@ -189,6 +189,16 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
                 const entryData = await api.getEntry(focusedEntryId);
                 setSelectedEntryData(entryData);
             } catch (error) {
+                toast[error.response.data.type](`Entry[${focusedEntryId}]: ${error.response.data.msg}`, {
+                    position: "bottom-right",
+                    theme: "colored",
+                    autoClose: error.response.data.autoClose,
+                    hideProgressBar: false,
+                    closeOnClick: true,
+                    pauseOnHover: true,
+                    draggable: true,
+                    progress: undefined,
+                });
                 console.error(error);
             }
         })()


### PR DESCRIPTION
`404` happens if the entry is removed because of database size limit (200MB by default). So we display a toast message to inform the user about inexistence of the entry.

![Screenshot from 2021-11-15 22-39-40](https://user-images.githubusercontent.com/2502080/141844307-7df45888-ffe8-4e59-b734-5fc64fc7e9e1.png)

![Screenshot from 2021-11-15 22-40-20](https://user-images.githubusercontent.com/2502080/141844316-a20e78b0-c6c8-49c0-8c1f-ab72bc599017.png)


