### PR TITLE
Prevent the crash on client-side in case of `text` being undefined in `FancyTextDisplay`

### DIFF
--- a/ui/src/components/UI/FancyTextDisplay.tsx
+++ b/ui/src/components/UI/FancyTextDisplay.tsx
@@ -17,6 +17,7 @@ interface Props {
 const FancyTextDisplay: React.FC<Props> = ({text, className, isPossibleToCopy = true, applyTextEllipsis = true, flipped = false, useTooltip= false, displayIconOnMouseOver = false, buttonOnly = false}) => {
     const [showCopiedNotification, setCopied] = useState(false);
     const [showTooltip, setShowTooltip] = useState(false);
+    if (text == null) text = '';
 
     const onCopy = () => {
         setCopied(true)

--- a/ui/src/components/UI/FancyTextDisplay.tsx
+++ b/ui/src/components/UI/FancyTextDisplay.tsx
@@ -17,7 +17,7 @@ interface Props {
 const FancyTextDisplay: React.FC<Props> = ({text, className, isPossibleToCopy = true, applyTextEllipsis = true, flipped = false, useTooltip= false, displayIconOnMouseOver = false, buttonOnly = false}) => {
     const [showCopiedNotification, setCopied] = useState(false);
     const [showTooltip, setShowTooltip] = useState(false);
-    if (text == null) text = '';
+    text = String(text);
 
     const onCopy = () => {
         setCopied(true)
@@ -48,7 +48,7 @@ const FancyTextDisplay: React.FC<Props> = ({text, className, isPossibleToCopy = 
     return (
         <p
             className={`FancyTextDisplay-Container ${className ? className : ''} ${displayIconOnMouseOver ? 'displayIconOnMouseOver ' : ''} ${applyTextEllipsis ? ' FancyTextDisplay-ContainerEllipsis' : ''}`}
-            title={text.toString()}
+            title={text}
             onMouseOver={ e => setShowTooltip(true)}
             onMouseLeave={ e => setShowTooltip(false)}
         >


### PR DESCRIPTION
Introduced by https://github.com/up9inc/mizu/pull/478 not present in a stable release.

Prevents:

![Screenshot from 2021-11-17 17-49-49](https://user-images.githubusercontent.com/2502080/142223905-7a336d1b-d220-4aad-a187-532227cb149f.png)
