### PR TITLE
Remove `SetHostname` method in HTTP extension

### DIFF
--- a/tap/extensions/http/main.go
+++ b/tap/extensions/http/main.go
@@ -124,15 +124,6 @@ func (d dissecting) Dissect(b *bufio.Reader, isClient bool, tcpID *api.TcpID, co
 	return nil
 }
 
-func SetHostname(address, newHostname string) string {
-	replacedUrl, err := url.Parse(address)
-	if err != nil {
-		return address
-	}
-	replacedUrl.Host = newHostname
-	return replacedUrl.String()
-}
-
 func (d dissecting) Analyze(item *api.OutputChannelItem, resolvedSource string, resolvedDestination string) *api.MizuEntry {
 	var host, authority, path, service string
 
@@ -189,9 +180,9 @@ func (d dissecting) Analyze(item *api.OutputChannelItem, resolvedSource string, 
 	reqDetails["queryString"] = mapSliceRebuildAsMap(reqDetails["_queryString"].([]interface{}))
 
 	if resolvedDestination != "" {
-		service = SetHostname(service, resolvedDestination)
+		service = resolvedDestination
 	} else if resolvedSource != "" {
-		service = SetHostname(service, resolvedSource)
+		service = resolvedSource
 	}
 
 	method := reqDetails["method"].(string)


### PR DESCRIPTION
Introduced by https://github.com/up9inc/mizu/pull/492 (not present in a stable release)

### Before:

![Screenshot from 2021-11-22 18-28-58](https://user-images.githubusercontent.com/2502080/142893394-ee7a34ac-d087-445a-83aa-6746cb0a2409.png)

### After:

![Screenshot from 2021-11-22 18-53-54](https://user-images.githubusercontent.com/2502080/142893416-705e4088-3b31-4d62-ab7c-84252dd47313.png)