### PR TITLE
Add response body to the error in case of failure

### DIFF
--- a/cli/apiserver/provider.go
+++ b/cli/apiserver/provider.go
@@ -63,13 +63,12 @@ func (provider *Provider) GetHealthStatus() (*shared.HealthResponse, error) {
 		return nil, err
 	} else if response.StatusCode > 299 {
 		responseBody := new(strings.Builder)
-		_, err := io.Copy(responseBody, response.Body)
 
-		if err != nil {
-			return nil, fmt.Errorf("status code: %d - (bad resopnse - %v)", response.StatusCode, err)
+		if _, err := io.Copy(responseBody, response.Body); err != nil {
+			return nil, fmt.Errorf("status code: %d - (bad response - %v)", response.StatusCode, err)
 		} else {
-			singlelineResponse := strings.ReplaceAll(responseBody.String(), "\n", "")
-			return nil, fmt.Errorf("status code: %d - (resopnse - %v)", response.StatusCode, singlelineResponse)
+			singleLineResponse := strings.ReplaceAll(responseBody.String(), "\n", "")
+			return nil, fmt.Errorf("status code: %d - (response - %v)", response.StatusCode, singleLineResponse)
 		}
 	} else {
 		defer response.Body.Close()


### PR DESCRIPTION
I encountered an error and it was hard to investigate due to lack of proper logs.

If a Kubernetes user doesn't have permissions to `services/proxy` in its rbac roles, the cli fail to connect to the api-server. The logs shows response code 403 but no more than that.

The api-server on the other hand, shows everything is fine - because kubernetes didn't even pass the request to it.

This PR add the response body to the log message in case of failure, it may help others with bad rbac.
