### PR TITLE
Revert the select entry behavior into original code and use `React.memo` BAD PERFORMANCE! (before #452) [TRA-3983 alternative 6]

### DIFF
--- a/ui/src/components/EntriesList.tsx
+++ b/ui/src/components/EntriesList.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from "react";
-import {EntryItem} from "./EntryListItem/EntryListItem";
+import {MemoizedEntryItem} from "./EntryListItem/EntryListItem";
 import styles from './style/EntriesList.module.sass';
 import ScrollableFeedVirtualized from "react-scrollable-feed-virtualized";
 import down from "./assets/downImg.svg";
@@ -27,7 +27,7 @@ export const EntriesList: React.FC<EntriesListProps> = ({entries, listEntryREF, 
                 <div id="list" ref={listEntryREF} className={styles.list}>
                     <ScrollableFeedVirtualized ref={scrollableRef} itemHeight={48} marginTop={10} onSnapBroken={onSnapBrokenEvent}>
                         {false /* TODO: why there is a need for something here (not necessarily false)? */}
-                        {entries.map(entry => <EntryItem key={entry.id}
+                        {entries.map(entry => <MemoizedEntryItem key={entry.id}
                                                         entry={entry}
                                                         setFocusedEntryId={setFocusedEntryId}
                                                         isSelected={focusedEntryId === entry.id.toString()}

--- a/ui/src/components/EntriesList.tsx
+++ b/ui/src/components/EntriesList.tsx
@@ -1,4 +1,5 @@
 import React, {useRef} from "react";
+import {EntryItem} from "./EntryListItem/EntryListItem";
 import styles from './style/EntriesList.module.sass';
 import ScrollableFeedVirtualized from "react-scrollable-feed-virtualized";
 import down from "./assets/downImg.svg";
@@ -6,6 +7,9 @@ import down from "./assets/downImg.svg";
 interface EntriesListProps {
     entries: any[];
     listEntryREF: any;
+    focusedEntryId: string;
+    setFocusedEntryId: (id: string) => void;
+    updateQuery: any;
     onSnapBrokenEvent: () => void;
     isSnappedToBottom: boolean;
     setIsSnappedToBottom: any;
@@ -14,7 +18,7 @@ interface EntriesListProps {
     startTime: number;
 }
 
-export const EntriesList: React.FC<EntriesListProps> = ({entries, listEntryREF, onSnapBrokenEvent, isSnappedToBottom, setIsSnappedToBottom, queriedCurrent, queriedTotal, startTime}) => {
+export const EntriesList: React.FC<EntriesListProps> = ({entries, listEntryREF, focusedEntryId, setFocusedEntryId, updateQuery, onSnapBrokenEvent, isSnappedToBottom, setIsSnappedToBottom, queriedCurrent, queriedTotal, startTime}) => {
 
     const scrollableRef = useRef(null);
 
@@ -23,7 +27,12 @@ export const EntriesList: React.FC<EntriesListProps> = ({entries, listEntryREF, 
                 <div id="list" ref={listEntryREF} className={styles.list}>
                     <ScrollableFeedVirtualized ref={scrollableRef} itemHeight={48} marginTop={10} onSnapBroken={onSnapBrokenEvent}>
                         {false /* TODO: why there is a need for something here (not necessarily false)? */}
-                        {entries}
+                        {entries.map(entry => <EntryItem key={entry.id}
+                                                        entry={entry}
+                                                        setFocusedEntryId={setFocusedEntryId}
+                                                        isSelected={focusedEntryId === entry.id.toString()}
+                                                        style={{}}
+                                                        updateQuery={updateQuery}/>)}
                     </ScrollableFeedVirtualized>
                     <button type="button"
                         className={`${styles.btnLive} ${isSnappedToBottom ? styles.hideButton : styles.showButton}`}

--- a/ui/src/components/EntryListItem/EntryListItem.tsx
+++ b/ui/src/components/EntryListItem/EntryListItem.tsx
@@ -239,3 +239,5 @@ export const EntryItem: React.FC<EntryProps> = ({entry, setFocusedEntryId, isSel
     </>
 
 }
+
+export const MemoizedEntryItem = React.memo(EntryItem);

--- a/ui/src/components/EntryListItem/EntryListItem.tsx
+++ b/ui/src/components/EntryListItem/EntryListItem.tsx
@@ -38,13 +38,12 @@ interface Rules {
 interface EntryProps {
     entry: Entry;
     setFocusedEntryId: (id: string) => void;
+    isSelected?: boolean;
     style: object;
     updateQuery: any;
 }
 
-export const EntryItem: React.FC<EntryProps> = ({entry, setFocusedEntryId, style, updateQuery}) => {
-
-    const [isSelected, setIsSelected] = useState(false);
+export const EntryItem: React.FC<EntryProps> = ({entry, setFocusedEntryId, isSelected, style, updateQuery}) => {
 
     const classification = getClassification(entry.statusCode)
     const numberOfRules = entry.rules.numberOfRules
@@ -121,10 +120,7 @@ export const EntryItem: React.FC<EntryProps> = ({entry, setFocusedEntryId, style
             id={entry.id.toString()}
             className={`${styles.row}
             ${isSelected && !rule && !contractEnabled ? styles.rowSelected : additionalRulesProperties}`}
-            onClick={() => {
-                setIsSelected(!isSelected);
-                setFocusedEntryId(entry.id.toString());
-            }}
+            onClick={() => setFocusedEntryId(entry.id.toString())}
             style={{
                 border: isSelected ? `1px ${entry.protocol.backgroundColor} solid` : "1px transparent solid",
                 position: "absolute",

--- a/ui/src/components/TrafficPage.tsx
+++ b/ui/src/components/TrafficPage.tsx
@@ -117,8 +117,7 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
                 case "entry":
                     const entry = message.data
                     if (!focusedEntryId) setFocusedEntryId(entry.id.toString())
-                    let newEntries = [...entries];
-                    setEntries([...newEntries, entry])
+                    setEntries([...entries, entry]);
                     break
                 case "status":
                     setTappingStatus(message.tappingStatus);


### PR DESCRIPTION
This PR completely reverts the optimization in https://github.com/up9inc/mizu/pull/452 and returns back to original code. Also uses `React.memo` for doing memoization with the hope of optimization. But unfortunately it does not speed up.