### PR TITLE
Rename `URL` field to `Target URI` in the UI to prevent confusion

### DIFF
--- a/tap/extensions/http/main.go
+++ b/tap/extensions/http/main.go
@@ -162,6 +162,7 @@ func (d dissecting) Analyze(item *api.OutputChannelItem, resolvedSource string, 
 	}
 
 	request["url"] = reqDetails["url"].(string)
+	reqDetails["targetUri"] = reqDetails["url"]
 	reqDetails["path"] = path
 	reqDetails["summary"] = path
 
@@ -269,9 +270,9 @@ func representRequest(request map[string]interface{}) (repRequest []interface{})
 			Selector: `request.method`,
 		},
 		{
-			Name:     "URL",
-			Value:    request["url"].(string),
-			Selector: `request.url`,
+			Name:     "Target URI",
+			Value:    request["targetUri"].(string),
+			Selector: `request.targetUri`,
 		},
 		{
 			Name:     "Path",


### PR DESCRIPTION
### Before

![Screenshot from 2021-11-25 05-01-43](https://user-images.githubusercontent.com/2502080/143365683-166a7b24-7c0f-414f-948b-11594cd579ed.png)

### After

![Screenshot from 2021-11-25 05-09-43](https://user-images.githubusercontent.com/2502080/143365688-4d74f439-c060-4ed2-8eae-6fac86b291cd.png)

![Screenshot from 2021-11-25 05-09-52](https://user-images.githubusercontent.com/2502080/143365695-45b9ddaf-8f23-49f3-b79f-435dbeee1d67.png)
