### PR TITLE
Hide `Encoding` field if it's `undefined` or empty in the UI

### DIFF
--- a/ui/src/components/EntryDetailed/EntrySections.tsx
+++ b/ui/src/components/EntryDetailed/EntrySections.tsx
@@ -130,7 +130,7 @@ export const EntryBodySection: React.FC<EntryBodySectionProps> = ({
             <table>
                 <tbody>
                     <EntryViewLine label={'Mime type'} value={contentType} updateQuery={updateQuery} selector={selector} overrideQueryValue={`r".*"`}/>
-                    <EntryViewLine label={'Encoding'} value={encoding} updateQuery={updateQuery} selector={selector} overrideQueryValue={`r".*"`}/>
+                    {encoding && <EntryViewLine label={'Encoding'} value={encoding} updateQuery={updateQuery} selector={selector} overrideQueryValue={`r".*"`}/>}
                 </tbody>
             </table>
 


### PR DESCRIPTION
### Before

![Screenshot from 2021-11-26 00-10-15](https://user-images.githubusercontent.com/2502080/143500413-bbde1af0-ec68-439c-b048-f4df89f25a0d.png)

![Screenshot from 2021-11-26 00-11-12](https://user-images.githubusercontent.com/2502080/143500419-3d4ca750-ba69-4124-869d-1aad7d593400.png)

### After

![Screenshot from 2021-11-26 00-13-04](https://user-images.githubusercontent.com/2502080/143500425-fdeb81ab-a480-4215-b10c-fe3719716eee.png)

![Screenshot from 2021-11-26 00-13-08](https://user-images.githubusercontent.com/2502080/143500428-c73dedb5-0ea8-485c-8a9f-f47bcf827280.png)