### PR TITLE
Fix the selected entry behavior by propagating the `focusedEntryId` through WebSocket (before #452) TRA-3983

### DIFF
--- a/agent/pkg/models/models.go
+++ b/agent/pkg/models/models.go
@@ -57,6 +57,11 @@ type WebSocketStartTimeMessage struct {
 	Data int64 `json:"data"`
 }
 
+type WebSocketFocusEntryMessage struct {
+	*shared.WebSocketMessageMetadata
+	Id int `json:"id"`
+}
+
 func CreateBaseEntryWebSocketMessage(base map[string]interface{}) ([]byte, error) {
 	message := &WebSocketEntryMessage{
 		WebSocketMessageMetadata: &shared.WebSocketMessageMetadata{
@@ -113,6 +118,16 @@ func CreateWebsocketStartTimeMessage(base int64) ([]byte, error) {
 			MessageType: shared.WebSocketMessageTypeStartTime,
 		},
 		Data: base,
+	}
+	return json.Marshal(message)
+}
+
+func CreateWebsocketFocusEntry(id int) ([]byte, error) {
+	message := &WebSocketFocusEntryMessage{
+		WebSocketMessageMetadata: &shared.WebSocketMessageMetadata{
+			MessageType: shared.WebSocketMessageFocusEntry,
+		},
+		Id: id,
 	}
 	return json.Marshal(message)
 }

--- a/shared/models.go
+++ b/shared/models.go
@@ -1,11 +1,12 @@
 package shared
 
 import (
+	"io/ioutil"
+	"strings"
+
 	"github.com/op/go-logging"
 	"github.com/up9inc/mizu/shared/logger"
 	"github.com/up9inc/mizu/tap/api"
-	"io/ioutil"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -21,6 +22,7 @@ const (
 	WebSocketMessageTypeToast         WebSocketMessageType = "toast"
 	WebSocketMessageTypeQueryMetadata WebSocketMessageType = "queryMetadata"
 	WebSocketMessageTypeStartTime     WebSocketMessageType = "startTime"
+	WebSocketMessageFocusEntry        WebSocketMessageType = "focusEntry"
 )
 
 type Resources struct {

--- a/ui/src/components/EntryDetailed.tsx
+++ b/ui/src/components/EntryDetailed.tsx
@@ -69,6 +69,7 @@ const EntrySummary: React.FC<any> = ({data, updateQuery}) => {
     return <EntryItem
         key={entry.id}
         entry={entry}
+        focusedEntryId={null}
         setFocusedEntryId={null}
         style={{}}
         updateQuery={updateQuery}

--- a/ui/src/components/EntryDetailed.tsx
+++ b/ui/src/components/EntryDetailed.tsx
@@ -72,7 +72,6 @@ const EntrySummary: React.FC<any> = ({data, updateQuery}) => {
         setFocusedEntryId={null}
         style={{}}
         updateQuery={updateQuery}
-        forceSelect={false}
         headingMode={true}
     />;
 };

--- a/ui/src/components/EntryListItem/EntryListItem.tsx
+++ b/ui/src/components/EntryListItem/EntryListItem.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React from "react";
 import styles from './EntryListItem.module.sass';
 import StatusCode, {getClassification, StatusCodeClassification} from "../UI/StatusCode";
 import Protocol, {ProtocolInterface} from "../UI/Protocol"
@@ -37,14 +37,15 @@ interface Rules {
 
 interface EntryProps {
     entry: Entry;
+    focusedEntryId: string;
     setFocusedEntryId: (id: string) => void;
     style: object;
     updateQuery: any;
 }
 
-export const EntryItem: React.FC<EntryProps> = ({entry, setFocusedEntryId, style, updateQuery}) => {
+export const EntryItem: React.FC<EntryProps> = ({entry, focusedEntryId, setFocusedEntryId, style, updateQuery}) => {
 
-    const [isSelected, setIsSelected] = useState(false);
+    const isSelected = focusedEntryId === entry.id.toString();
 
     const classification = getClassification(entry.statusCode)
     const numberOfRules = entry.rules.numberOfRules
@@ -122,7 +123,6 @@ export const EntryItem: React.FC<EntryProps> = ({entry, setFocusedEntryId, style
             className={`${styles.row}
             ${isSelected && !rule && !contractEnabled ? styles.rowSelected : additionalRulesProperties}`}
             onClick={() => {
-                setIsSelected(!isSelected);
                 setFocusedEntryId(entry.id.toString());
             }}
             style={{

--- a/ui/src/components/TrafficPage.tsx
+++ b/ui/src/components/TrafficPage.tsx
@@ -133,7 +133,6 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
                             setFocusedEntryId={setFocusedEntryId}
                             style={{}}
                             updateQuery={updateQuery}
-                            forceSelect={forceSelect}
                             headingMode={false}
                         />
                     ]);

--- a/ui/src/components/TrafficPage.tsx
+++ b/ui/src/components/TrafficPage.tsx
@@ -119,12 +119,17 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
             switch (message.messageType) {
                 case "entry":
                     const entry = message.data;
-                    if (!focusedEntryId) setFocusedEntryId(entry.id.toString());
+                    var focusThis = false;
+                    if (!focusedEntryId) {
+                        focusThis = true;
+                        setFocusedEntryId(entry.id.toString());
+                    }
                     setEntriesBuffer([
                         ...entriesBuffer,
                         <EntryItem
                             key={entry.id}
                             entry={entry}
+                            focusedEntryId={focusThis ? entry.id.toString() : focusedEntryId}
                             setFocusedEntryId={setFocusedEntryId}
                             style={{}}
                             updateQuery={updateQuery}
@@ -185,6 +190,16 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
     useEffect(() => {
         if (!focusedEntryId) return;
         setSelectedEntryData(null);
+
+        // To achieve selecting only one entry, render all elements in the buffer
+        // with the current `focusedEntryId` value.
+        entriesBuffer.forEach((entry: any, i: number) => {
+            entriesBuffer[i] = React.cloneElement(entry, {
+                focusedEntryId: focusedEntryId
+            });
+        })
+        setEntries(entriesBuffer);
+
         (async () => {
             try {
                 const entryData = await api.getEntry(focusedEntryId);
@@ -203,6 +218,7 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
                 console.error(error);
             }
         })()
+        // eslint-disable-next-line
     }, [focusedEntryId])
 
     const toggleConnection = () => {

--- a/ui/src/components/TrafficPage.tsx
+++ b/ui/src/components/TrafficPage.tsx
@@ -194,11 +194,13 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
 
         // To achieve selecting only one entry, render all elements in the buffer
         // with the current `focusedEntryId` value.
-        entriesBuffer.forEach((entry: any, i: number) => {
-            entriesBuffer[i] = React.cloneElement(entry, {
+        let entriesBufferSnapshot = [...entriesBuffer];
+        entriesBufferSnapshot.forEach((entry: any, i: number) => {
+            entriesBufferSnapshot[i] = React.cloneElement(entry, {
                 focusedEntryId: focusedEntryId
             });
         })
+        setEntriesBuffer(entriesBufferSnapshot);
         setEntries(entriesBuffer);
 
         (async () => {

--- a/ui/src/components/TrafficPage.tsx
+++ b/ui/src/components/TrafficPage.tsx
@@ -166,6 +166,16 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
                 case "startTime":
                     setStartTime(message.data);
                     break;
+                case "focusEntry":
+                    // To achieve selecting only one entry, render all elements in the buffer
+                    // with the current `focusedEntryId` value.
+                    entriesBuffer.forEach((entry: any, i: number) => {
+                        entriesBuffer[i] = React.cloneElement(entry, {
+                            focusedEntryId: focusedEntryId
+                        });
+                    })
+                    setEntries(entriesBuffer);
+                    break;
                 default:
                     console.error(`unsupported websocket message type, Got: ${message.messageType}`)
             }
@@ -192,16 +202,9 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
         if (!focusedEntryId) return;
         setSelectedEntryData(null);
 
-        // To achieve selecting only one entry, render all elements in the buffer
-        // with the current `focusedEntryId` value.
-        let entriesBufferSnapshot = [...entriesBuffer];
-        entriesBufferSnapshot.forEach((entry: any, i: number) => {
-            entriesBufferSnapshot[i] = React.cloneElement(entry, {
-                focusedEntryId: focusedEntryId
-            });
-        })
-        setEntriesBuffer(entriesBufferSnapshot);
-        setEntries(entriesBuffer);
+        if (ws.current.readyState === WebSocket.OPEN) {
+            ws.current.send(focusedEntryId);
+        }
 
         (async () => {
             try {
@@ -223,7 +226,6 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
                 console.error(error);
             }
         })()
-        // eslint-disable-next-line
     }, [focusedEntryId])
 
     const toggleConnection = () => {


### PR DESCRIPTION
Introduces a slight delay in case of network bottleneck:

https://user-images.githubusercontent.com/2502080/144033464-a9944bbd-b051-4720-86fd-63c3a8827bee.mp4

https://user-images.githubusercontent.com/2502080/144034777-59e128ee-a882-4908-8079-815b5a64cfc0.mp4

No racing, no incorrect behavior.

