### PR TITLE
Fix the styling of `Queryable` under `StatusCode` and `Summary` components

### DIFF
--- a/ui/src/components/EntryListItem/EntryListItem.module.sass
+++ b/ui/src/components/EntryListItem/EntryListItem.module.sass
@@ -68,9 +68,8 @@
   flex-direction: column
   overflow: hidden
   padding-right: 10px
+  padding-left: 10px
   flex-grow: 1
-  padding-top: 5px
-  margin-left: -6px
 
 .separatorRight
   display: flex

--- a/ui/src/components/UI/StatusCode.tsx
+++ b/ui/src/components/UI/StatusCode.tsx
@@ -20,8 +20,9 @@ const StatusCode: React.FC<EntryProps> = ({statusCode, updateQuery}) => {
     return <Queryable
         query={`response.status == ${statusCode}`}
         updateQuery={updateQuery}
-        style={{minWidth: "68px"}}
         displayIconOnMouseOver={true}
+        flipped={true}
+        iconStyle={{marginTop: "40px"}}
     >
         <span
             title="Status Code"

--- a/ui/src/components/UI/Summary.tsx
+++ b/ui/src/components/UI/Summary.tsx
@@ -17,6 +17,7 @@ export const Summary: React.FC<SummaryProps> = ({method, summary, updateQuery}) 
             className={`${miscStyles.protocol} ${miscStyles.method}`}
             updateQuery={updateQuery}
             displayIconOnMouseOver={true}
+            style={{whiteSpace: "nowrap"}}
         >
             <span>
                 {method}


### PR DESCRIPTION
Introduced by https://github.com/up9inc/mizu/pull/512

### Before:

![Screenshot from 2021-12-04 10-35-28](https://user-images.githubusercontent.com/2502080/144702347-17fd8d5f-5e4b-4302-ab82-b99c12a4e24f.png)

### After:

![Screenshot from 2021-12-04 10-56-56](https://user-images.githubusercontent.com/2502080/144702349-323f2fb3-54e9-4fb9-aafe-13e68087565e.png)