### PR TITLE
Fix the CSS issues in queryable vertical protocol element

### DIFF
--- a/ui/src/components/EntryListItem/EntryListItem.module.sass
+++ b/ui/src/components/EntryListItem/EntryListItem.module.sass
@@ -68,7 +68,6 @@
   flex-direction: column
   overflow: hidden
   padding-right: 10px
-  padding-left: 10px
   flex-grow: 1
 
 .separatorRight

--- a/ui/src/components/EntryListItem/EntryListItem.tsx
+++ b/ui/src/components/EntryListItem/EntryListItem.tsx
@@ -120,6 +120,10 @@ export const EntryItem: React.FC<EntryProps> = ({entry, focusedEntryId, setFocus
             break;
     }
 
+    const isStatusCodeEnabled = ((entry.protocol.name === "http" && "statusCode" in entry) || entry.statusCode !== 0);
+    var endpointServiceContainer = "10px";
+    if (!isStatusCodeEnabled) endpointServiceContainer = "20px";
+
     return <>
         <div
             id={`entry-${entry.id.toString()}`}
@@ -142,10 +146,10 @@ export const EntryItem: React.FC<EntryProps> = ({entry, focusedEntryId, setFocus
                 horizontal={false}
                 updateQuery={updateQuery}
             /> : null}
-            {((entry.protocol.name === "http" && "statusCode" in entry) || entry.statusCode !== 0) && <div>
+            {isStatusCodeEnabled && <div>
                 <StatusCode statusCode={entry.statusCode} updateQuery={updateQuery}/>
             </div>}
-            <div className={styles.endpointServiceContainer}>
+            <div className={styles.endpointServiceContainer} style={{paddingLeft: endpointServiceContainer}}>
                 <Summary method={entry.method} summary={entry.summary} updateQuery={updateQuery}/>
                 <div className={styles.service}>
                     <Queryable

--- a/ui/src/components/UI/Protocol.tsx
+++ b/ui/src/components/UI/Protocol.tsx
@@ -48,7 +48,7 @@ const Protocol: React.FC<ProtocolProps> = ({protocol, horizontal, updateQuery}) 
             updateQuery={updateQuery}
             displayIconOnMouseOver={true}
             flipped={false}
-            iconStyle={{marginTop: "48px"}}
+            iconStyle={{marginTop: "52px", marginRight: "10px", zIndex: 1000}}
         >
             <span
                 className={`${styles.base} ${styles.vertical}`}
@@ -56,6 +56,7 @@ const Protocol: React.FC<ProtocolProps> = ({protocol, horizontal, updateQuery}) 
                     backgroundColor: protocol.backgroundColor,
                     color: protocol.foregroundColor,
                     fontSize: protocol.fontSize,
+                    marginRight: "-20px",
                 }}
                 title={protocol.longName}
             >

--- a/ui/src/components/UI/StatusCode.tsx
+++ b/ui/src/components/UI/StatusCode.tsx
@@ -22,7 +22,7 @@ const StatusCode: React.FC<EntryProps> = ({statusCode, updateQuery}) => {
         updateQuery={updateQuery}
         displayIconOnMouseOver={true}
         flipped={true}
-        iconStyle={{marginTop: "40px"}}
+        iconStyle={{marginTop: "40px", paddingLeft: "10px"}}
     >
         <span
             title="Status Code"


### PR DESCRIPTION
Fixes the plus icon for the queryable vertical protocol element that was not clickable because of a CSS issue.

### Before

![Screenshot from 2021-12-10 22-42-45](https://user-images.githubusercontent.com/2502080/145632608-cb263bfd-7f08-4a82-821c-e71d13015f09.png)

![Screenshot from 2021-12-10 22-42-57](https://user-images.githubusercontent.com/2502080/145632613-bd5921e5-8388-4d8b-b3b4-28f16d3644a0.png)

### After

![Screenshot from 2021-12-10 22-42-10](https://user-images.githubusercontent.com/2502080/145632598-f4dbc643-4c60-483f-b8a7-d89fcc540238.png)

![Screenshot from 2021-12-10 22-42-20](https://user-images.githubusercontent.com/2502080/145632605-4f33df2a-0f11-4d80-b52a-08f06958fdb5.png)