### PR TITLE
Fix the CSS issue in `Queryable` component for `src.name` field on heading mode

### DIFF
--- a/ui/src/components/EntryListItem/EntryListItem.tsx
+++ b/ui/src/components/EntryListItem/EntryListItem.tsx
@@ -161,7 +161,7 @@ export const EntryItem: React.FC<EntryProps> = ({entry, focusedEntryId, setFocus
                         displayIconOnMouseOver={true}
                         flipped={true}
                         style={{marginTop: "-4px", overflow: "visible"}}
-                        iconStyle={{marginTop: "4px", left: "68px", position: "absolute"}}
+                        iconStyle={!headingMode ? {marginTop: "4px", left: "68px", position: "absolute"} : {marginTop: "4px", left: "calc(50vw + 41px)", position: "absolute"}}
                     >
                         <span
                             title="Source Name"


### PR DESCRIPTION
Introduced by https://github.com/up9inc/mizu/pull/525

> Note: Mouse cursor is actually hovering on the related element. It's just I forgot to enable mouse cursor while taking the screenshots. (`front-end.sock-shop` which is `src.name` field on right-pane)

### Before

See how the plus icon is misplaced on hover;

![Screenshot from 2021-12-15 02-33-57](https://user-images.githubusercontent.com/2502080/146096564-dbd922f8-eaa0-425e-8171-97c7b09195af.png)

### After

![Screenshot from 2021-12-15 02-36-35](https://user-images.githubusercontent.com/2502080/146096573-ec111f5a-686a-4076-b491-62ab879f4ecc.png)

![Screenshot from 2021-12-15 02-36-58](https://user-images.githubusercontent.com/2502080/146096581-abf635f8-73dd-4108-a157-532c5da28bc6.png)


