### PR TITLE
Fix `React Hook useEffect has a missing dependency: 'handleQueryChange'` warning

### DIFF
--- a/ui/src/components/TrafficPage.tsx
+++ b/ui/src/components/TrafficPage.tsx
@@ -91,7 +91,7 @@ export const TrafficPage: React.FC<TrafficPageProps> = ({setAnalyzeStatus, onTLS
 
     useEffect(() => {
         handleQueryChange(query);
-    }, [query]);
+    }, [query, handleQueryChange]);
 
     useEffect(() => {
         if (query) {


### PR DESCRIPTION
The warning is introduced with https://github.com/up9inc/mizu/pull/542