### PR TITLE
Fix the acceptance tests and a typo in `CONFIGURATION.md`

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'develop'
   push:
     branches:
       - 'develop'

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'develop'
   push:
     branches:
       - 'develop'

--- a/acceptanceTests/logs_test.go
+++ b/acceptanceTests/logs_test.go
@@ -81,8 +81,13 @@ func TestLogs(t *testing.T) {
 		logsFileNames = append(logsFileNames, file.Name)
 	}
 
-	if !Contains(logsFileNames, "mizu.mizu-api-server.log") {
+	if !Contains(logsFileNames, "mizu.mizu-api-server.mizu-api-server.log") {
 		t.Errorf("api server logs not found")
+		return
+	}
+
+	if !Contains(logsFileNames, "mizu.mizu-api-server.basenine.log") {
+		t.Errorf("basenine logs not found")
 		return
 	}
 

--- a/acceptanceTests/logs_test.go
+++ b/acceptanceTests/logs_test.go
@@ -179,8 +179,13 @@ func TestLogsPath(t *testing.T) {
 		logsFileNames = append(logsFileNames, file.Name)
 	}
 
-	if !Contains(logsFileNames, "mizu.mizu-api-server.log") {
+	if !Contains(logsFileNames, "mizu.mizu-api-server.mizu-api-server.log") {
 		t.Errorf("api server logs not found")
+		return
+	}
+
+	if !Contains(logsFileNames, "mizu.mizu-api-server.basenine.log") {
+		t.Errorf("basenine logs not found")
 		return
 	}
 

--- a/acceptanceTests/tap_test.go
+++ b/acceptanceTests/tap_test.go
@@ -862,8 +862,13 @@ func TestTapDumpLogs(t *testing.T) {
 		logsFileNames = append(logsFileNames, file.Name)
 	}
 
-	if !Contains(logsFileNames, "mizu.mizu-api-server.log") {
+	if !Contains(logsFileNames, "mizu.mizu-api-server.mizu-api-server.log") {
 		t.Errorf("api server logs not found")
+		return
+	}
+
+	if !Contains(logsFileNames, "mizu.mizu-api-server.basenine.log") {
+		t.Errorf("basenine logs not found")
 		return
 	}
 

--- a/acceptanceTests/testsUtils.go
+++ b/acceptanceTests/testsUtils.go
@@ -92,7 +92,7 @@ func getDefaultCommandArgs() []string {
 	setFlag := "--set"
 	telemetry := "telemetry=false"
 	agentImage := "agent-image=gcr.io/up9-docker-hub/mizu/ci:0.0.0"
-	imagePullPolicy := "image-pull-policy=Never"
+	imagePullPolicy := "image-pull-policy=IfNotPresent"
 	headless := "headless=true"
 
 	return []string{setFlag, telemetry, setFlag, agentImage, setFlag, imagePullPolicy, setFlag, headless}

--- a/cli/mizu/fsUtils/mizuLogsUtils.go
+++ b/cli/mizu/fsUtils/mizuLogsUtils.go
@@ -38,18 +38,20 @@ func DumpLogs(ctx context.Context, provider *kubernetes.Provider, filePath strin
 	defer zipWriter.Close()
 
 	for _, pod := range pods {
-		logs, err := provider.GetPodLogs(ctx, pod.Namespace, pod.Name)
-		if err != nil {
-			logger.Log.Errorf("Failed to get logs, %v", err)
-			continue
-		} else {
-			logger.Log.Debugf("Successfully read log length %d for pod: %s.%s", len(logs), pod.Namespace, pod.Name)
-		}
+		for _, container := range pod.Spec.Containers {
+			logs, err := provider.GetPodLogs(ctx, pod.Namespace, pod.Name, container.Name)
+			if err != nil {
+				logger.Log.Errorf("Failed to get logs, %v", err)
+				continue
+			} else {
+				logger.Log.Debugf("Successfully read log length %d for pod: %s.%s.%s", len(logs), pod.Namespace, pod.Name, container.Name)
+			}
 
-		if err := AddStrToZip(zipWriter, logs, fmt.Sprintf("%s.%s.log", pod.Namespace, pod.Name)); err != nil {
-			logger.Log.Errorf("Failed write logs, %v", err)
-		} else {
-			logger.Log.Debugf("Successfully added log length %d from pod: %s.%s", len(logs), pod.Namespace, pod.Name)
+			if err := AddStrToZip(zipWriter, logs, fmt.Sprintf("%s.%s.%s.log", pod.Namespace, pod.Name, container.Name)); err != nil {
+				logger.Log.Errorf("Failed write logs, %v", err)
+			} else {
+				logger.Log.Debugf("Successfully added log length %d from pod: %s.%s.%s", len(logs), pod.Namespace, pod.Name, container.Name)
+			}
 		}
 	}
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,7 +25,7 @@ Please make sure to use full option name (`tap.dry-run` as opposed to `dry-run` 
 
 * `dump-logs` - if set to `true`, saves log files for all Mizu components (tapper, api-server, CLI) in a zip file under `$HOME/.mizu`. Default value is `false`
 
-* `image-pull-policy` - container image pull policy for Kubernetes, default value `Always`. Other accepted values are `Never` or `IfNotExist`. Please mind the implications when changing this.
+* `image-pull-policy` - container image pull policy for Kubernetes, default value `Always`. Other accepted values are `Never` or `IfNotPresent`. Please mind the implications when changing this.
 
 * `kube-config-path` - path to alternative kubeconfig file to use for all interactions with Kubernetes cluster. By default - `$HOME/.kubeconfig`
 

--- a/shared/kubernetes/provider.go
+++ b/shared/kubernetes/provider.go
@@ -943,8 +943,8 @@ func (provider *Provider) ListAllNamespaces(ctx context.Context) ([]core.Namespa
 	return namespaces.Items, err
 }
 
-func (provider *Provider) GetPodLogs(ctx context.Context, namespace string, podName string) (string, error) {
-	podLogOpts := core.PodLogOptions{}
+func (provider *Provider) GetPodLogs(ctx context.Context, namespace string, podName string, containerName string) (string, error) {
+	podLogOpts := core.PodLogOptions{Container: containerName}
 	req := provider.clientSet.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
 	podLogs, err := req.Stream(ctx)
 	if err != nil {


### PR DESCRIPTION
Also includes the container name into the log fetching function. So log filenames become:

```
mizu.mizu-api-server.basenine.log
mizu.mizu-api-server.mizu-api-server.log
```

Related PRs:

- https://github.com/up9inc/mizu/pull/603
- https://github.com/up9inc/mizu/pull/583