### PR TITLE
Display Redis value as `EntryBodySection`

### DIFF
--- a/tap/extensions/redis/helpers.go
+++ b/tap/extensions/redis/helpers.go
@@ -43,11 +43,6 @@ func representGeneric(generic map[string]interface{}, selectorPrefix string) (re
 			Selector: fmt.Sprintf("%skey", selectorPrefix),
 		},
 		{
-			Name:     "Value",
-			Value:    generic["value"].(string),
-			Selector: fmt.Sprintf("%svalue", selectorPrefix),
-		},
-		{
 			Name:     "Keyword",
 			Value:    generic["keyword"].(string),
 			Selector: fmt.Sprintf("%skeyword", selectorPrefix),
@@ -57,6 +52,13 @@ func representGeneric(generic map[string]interface{}, selectorPrefix string) (re
 		Type:  api.TABLE,
 		Title: "Details",
 		Data:  string(details),
+	})
+
+	representation = append(representation, api.SectionData{
+		Type:     api.BODY,
+		Title:    "Value",
+		Data:     generic["value"].(string),
+		Selector: fmt.Sprintf("%svalue", selectorPrefix),
 	})
 
 	return

--- a/ui/src/components/EntryDetailed/EntrySections.tsx
+++ b/ui/src/components/EntryDetailed/EntrySections.tsx
@@ -107,6 +107,7 @@ export const EntrySectionContainer: React.FC<EntrySectionContainerProps> = ({tit
 }
 
 interface EntryBodySectionProps {
+    title: string,
     content: any,
     color: string,
     updateQuery: any,
@@ -116,6 +117,7 @@ interface EntryBodySectionProps {
 }
 
 export const EntryBodySection: React.FC<EntryBodySectionProps> = ({
+    title,
     color,
     updateQuery,
     content,
@@ -167,7 +169,7 @@ export const EntryBodySection: React.FC<EntryBodySectionProps> = ({
 
     return <React.Fragment>
         {content && content?.length > 0 && <EntrySectionContainer
-                                                title='Body'
+                                                title={title}
                                                 color={color}
                                                 query={`${selector} == r".*"`}
                                                 updateQuery={updateQuery}

--- a/ui/src/components/EntryDetailed/EntryViewer.tsx
+++ b/ui/src/components/EntryDetailed/EntryViewer.tsx
@@ -21,7 +21,7 @@ const SectionsRepresentation: React.FC<any> = ({data, color, updateQuery}) => {
                     break;
                 case SectionTypes.SectionBody:
                     sections.push(
-                        <EntryBodySection key={i} color={color} content={row.data} updateQuery={updateQuery} encoding={row.encoding} contentType={row.mimeType} selector={row.selector}/>
+                        <EntryBodySection key={i} title={row.title} color={color} content={row.data} updateQuery={updateQuery} encoding={row.encoding} contentType={row.mimeType} selector={row.selector}/>
                     )
                     break;
                 default:


### PR DESCRIPTION
Ignore the unresolved `src.name` and `dst.name` fields. It's because I'm running it locally.

### Before

![Screenshot from 2022-01-14 21-45-42](https://user-images.githubusercontent.com/2502080/149569507-470b2a3f-9b0e-42ec-a13f-e2efee4d64d9.png)

![Screenshot from 2022-01-14 21-45-46](https://user-images.githubusercontent.com/2502080/149569515-f5cb2d92-5478-4e19-b839-2682fc42f529.png)

### After

![Screenshot from 2022-01-14 21-51-14](https://user-images.githubusercontent.com/2502080/149569531-9a992504-9482-45fb-9347-db42e013bd72.png)

![Screenshot from 2022-01-14 21-51-17](https://user-images.githubusercontent.com/2502080/149569539-ae8155a9-1509-4419-ba4c-e57d0134fdb5.png)

