### PR TITLE
Sort key-value pairs on client-side in `EntryTableSection`

### DIFF
--- a/ui/src/components/EntryDetailed/EntrySections.tsx
+++ b/ui/src/components/EntryDetailed/EntrySections.tsx
@@ -205,13 +205,27 @@ interface EntrySectionProps {
 }
 
 export const EntryTableSection: React.FC<EntrySectionProps> = ({title, color, arrayToIterate, updateQuery}) => {
+    let arrayToIterateSorted: any[];
+    if (arrayToIterate) {
+        arrayToIterateSorted = arrayToIterate.sort((a, b) => {
+            if (a.name > b.name) {
+                return 1;
+            }
+
+            if (a.name < b.name) {
+                return -1;
+            }
+
+            return 0;
+        });
+    }
     return <React.Fragment>
         {
             arrayToIterate && arrayToIterate.length > 0 ?
                 <EntrySectionContainer title={title} color={color}>
                     <table>
                         <tbody>
-                            {arrayToIterate.map(({name, value, selector}, index) => <EntryViewLine
+                            {arrayToIterateSorted.map(({name, value, selector}, index) => <EntryViewLine
                                 key={index}
                                 label={name}
                                 value={value}


### PR DESCRIPTION
Ignore the unresolved `src.name` and `dst.name` fields. It's because I'm running it locally.

### Before

![Screenshot from 2022-01-14 22-02-58](https://user-images.githubusercontent.com/2502080/149571092-faa83a6b-deb6-4d3c-a16e-319a9c04544f.png)

![Screenshot from 2022-01-14 22-03-00](https://user-images.githubusercontent.com/2502080/149571101-163e93d2-8932-44e5-8faa-358313eaf243.png)

![Screenshot from 2022-01-14 22-03-03](https://user-images.githubusercontent.com/2502080/149571112-397637ab-c2a2-4cf9-9123-6568e93b3c08.png)

### After

![Screenshot from 2022-01-14 22-01-19](https://user-images.githubusercontent.com/2502080/149571124-f8331a19-d153-431d-a6fe-1d73fa25607f.png)

![Screenshot from 2022-01-14 22-01-22](https://user-images.githubusercontent.com/2502080/149571133-7ce20ade-458a-450a-9f22-7d7c455c619d.png)

![Screenshot from 2022-01-14 22-01-25](https://user-images.githubusercontent.com/2502080/149571139-d1f30ce8-bd9a-497d-8134-5a7dbfb042b1.png)

