### PR TITLE
Fix `EntryItem` border on heading mode

### DIFF
--- a/ui/src/components/EntryListItem/EntryListItem.tsx
+++ b/ui/src/components/EntryListItem/EntryListItem.tsx
@@ -140,7 +140,7 @@ export const EntryItem: React.FC<EntryProps> = ({entry, style, headingMode}) => 
                 setFocusedEntryId(entry.id.toString());
             }}
             style={{
-                border: isSelected ? `1px ${entry.proto.backgroundColor} solid` : "1px transparent solid",
+                border: isSelected && !headingMode ? `1px ${entry.proto.backgroundColor} solid` : "1px transparent solid",
                 position: !headingMode ? "absolute" : "unset",
                 top: style['top'],
                 marginTop: !headingMode ? style['marginTop'] : "10px",


### PR DESCRIPTION
Fixes;

![Screenshot from 2022-01-17 16-44-58](https://user-images.githubusercontent.com/2502080/149929934-555bf251-26c7-4701-bc57-6590aae6418f.png)

Introduced by https://github.com/up9inc/mizu/commit/5fed5808d228553c07e053df77b96f8da7349fc8#diff-c77e7a49451f5f399438adaf74d06341ea85aaf641b9d502975a09606aa9e5e8R54