### PR TITLE
Removing concurrency group from acceptance test workflow

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - 'develop'
 
-concurrency:
-  group: mizu-acceptance-tests-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   run-acceptance-tests:
     name: Run acceptance tests


### PR DESCRIPTION
Motivation: get the exact commit where the acceptance tests started to fail