### PR TITLE
Add help messages of make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,10 @@ clean-agent: ## Clean agent.
 clean-cli:  ## Clean CLI.
 	@(cd cli; make clean ; echo "CLI cleanup done" )
 
-clean-docker:
+clean-docker:  ## Run clen docker
 	@(echo "DOCKER cleanup - NOT IMPLEMENTED YET " )
 
-test-lint:
+test-lint:  ## Run lint on all modules
 	cd agent && golangci-lint run
 	cd shared && golangci-lint run
 	cd tap && golangci-lint run
@@ -92,17 +92,17 @@ test-lint:
 	cd tap/api && golangci-lint run
 	cd tap/extensions/ && for D in */; do cd $$D && golangci-lint run && cd ..; done
 
-test-cli:
+test-cli:  ## Run cli tests
 	@echo "running cli tests"; cd cli && $(MAKE) test
 
-test-agent:
+test-agent:  ## Run agent tests
 	@echo "running agent tests"; cd agent && $(MAKE) test
 
-test-shared:
+test-shared:  ## Run shared tests
 	@echo "running shared tests"; cd shared && $(MAKE) test
 
-test-extensions:
+test-extensions:  ## Run extensions tests
 	@echo "running http tests"; cd tap/extensions/http && $(MAKE) test
 
-acceptance-test:
+acceptance-test:  ## Run acceptance tests
 	@echo "running acceptance tests"; cd acceptanceTests && $(MAKE) test

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -14,7 +14,7 @@ help: ## This help.
 install:
 	go install mizu.go
 
-build-debug:
+build-debug:  ## Build mizu CLI for debug
 	export GCLFAGS='-gcflags="all=-N -l"'
 	${MAKE} build
 

--- a/tap/extensions/http/Makefile
+++ b/tap/extensions/http/Makefile
@@ -9,8 +9,8 @@ test-update: test-pull-bin
 
 test-pull-bin:
 	@mkdir -p bin
-	@[ "${skipbin}" ] && echo "Skipping downloading BINs" || gsutil -m cp gs://static.up9.io/mizu/test-pcap/bin/http/\*.bin bin
+	@[ "${skipbin}" ] && echo "Skipping downloading BINs" || gsutil  -o 'GSUtil:parallel_process_count=5' -o 'GSUtil:parallel_thread_count=5'  -m cp gs://static.up9.io/mizu/test-pcap/bin/http/\*.bin bin
 
 test-pull-expect:
 	@mkdir -p expect
-	@[ "${skipexpect}" ] && echo "Skipping downloading expected JSONs" || gsutil -m cp -r gs://static.up9.io/mizu/test-pcap/expect/http/\* expect
+	@[ "${skipexpect}" ] && echo "Skipping downloading expected JSONs" || gsutil  -o 'GSUtil:parallel_process_count=5' -o 'GSUtil:parallel_thread_count=5'  -m cp -r gs://static.up9.io/mizu/test-pcap/expect/http/\* expect


### PR DESCRIPTION
parallel_process_count in mac is higher than linux and it causes problems when running it. 
so I used the -o flag and override the config to be "5" so it will work without need to change in every developer laptop.