### PR TITLE
Take ownership over DaemonSet

### DIFF
--- a/cli/resources/createResources.go
+++ b/cli/resources/createResources.go
@@ -80,7 +80,7 @@ func CreateInstallMizuResources(ctx context.Context, kubernetesProvider *kuberne
 	}
 	logger.Log.Infof("configmap/%v created", kubernetes.ConfigMapName)
 
-	_, err := createRBACIfNecessary(ctx, kubernetesProvider, isNsRestrictedMode, mizuResourcesNamespace, []string{"pods", "services", "endpoints", "namespaces"})
+	_, err := createRBACIfNecessary(ctx, kubernetesProvider, isNsRestrictedMode, mizuResourcesNamespace, []string{"pods", "services", "endpoints", "namespaces", "deployments"})
 	if err != nil {
 		return err
 	}

--- a/shared/kubernetes/provider.go
+++ b/shared/kubernetes/provider.go
@@ -952,11 +952,6 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	labelSelector := applyconfmeta.LabelSelector()
 	labelSelector.WithMatchLabels(map[string]string{"app": tapperPodName})
 
-	applyOptions := metav1.ApplyOptions{
-		Force: true,
-		FieldManager: fieldManagerName,
-	}
-
 	daemonSet := applyconfapp.DaemonSet(daemonSetName, namespace)
 	daemonSet.
 		WithLabels(map[string]string{
@@ -965,7 +960,7 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 		}).
 		WithSpec(applyconfapp.DaemonSetSpec().WithSelector(labelSelector).WithTemplate(podTemplate))
 
-	_, err = provider.clientSet.AppsV1().DaemonSets(namespace).Apply(ctx, daemonSet, applyOptions)
+	_, err = provider.clientSet.AppsV1().DaemonSets(namespace).Apply(ctx, daemonSet, metav1.ApplyOptions{FieldManager: fieldManagerName})
 	return err
 }
 

--- a/shared/kubernetes/provider.go
+++ b/shared/kubernetes/provider.go
@@ -949,11 +949,20 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	})
 	podTemplate.WithSpec(podSpec)
 
+	ownerReferences := applyconfmeta.OwnerReference()
+	// ownerReferences.WithAPIVersion()
+	ownerReferences.WithKind("DaemonSet")
+	ownerReferences.WithName(daemonSetName)
+	// ownerReferences.WithUID()
+	// ownerReferences.WithController()
+	// ownerReferences.WithBlockOwnerDeletion()
+
 	labelSelector := applyconfmeta.LabelSelector()
 	labelSelector.WithMatchLabels(map[string]string{"app": tapperPodName})
 
 	daemonSet := applyconfapp.DaemonSet(daemonSetName, namespace)
 	daemonSet.
+		WithOwnerReferences(ownerReferences).
 		WithLabels(map[string]string{
 			LabelManagedBy: provider.managedBy,
 			LabelCreatedBy: provider.createdBy,

--- a/shared/kubernetes/provider.go
+++ b/shared/kubernetes/provider.go
@@ -952,6 +952,11 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	labelSelector := applyconfmeta.LabelSelector()
 	labelSelector.WithMatchLabels(map[string]string{"app": tapperPodName})
 
+	applyOptions := metav1.ApplyOptions{
+		Force: true,
+		FieldManager: fieldManagerName,
+	}
+
 	daemonSet := applyconfapp.DaemonSet(daemonSetName, namespace)
 	daemonSet.
 		WithLabels(map[string]string{
@@ -960,7 +965,7 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 		}).
 		WithSpec(applyconfapp.DaemonSetSpec().WithSelector(labelSelector).WithTemplate(podTemplate))
 
-	_, err = provider.clientSet.AppsV1().DaemonSets(namespace).Apply(ctx, daemonSet, metav1.ApplyOptions{FieldManager: fieldManagerName})
+	_, err = provider.clientSet.AppsV1().DaemonSets(namespace).Apply(ctx, daemonSet, applyOptions)
 	return err
 }
 


### PR DESCRIPTION
Set mizu-api-server as the owner of mizu-tapper-daemonset.
This will cause k8s to delete mizu-tapper-daemonset if mizu-api-server is deleted.

The problem this PR solves:
In the case where Mizu is installed via Helm and not with the `mizu install` command, then there are left overs after `helm uninstall`. The reason for the leftovers is that Helm creates the api server but doesn't create the tappers. It doesn't know it needs to delete the tapper daemonset.
If mizu-api-server is marked as the owner of mizu-tapper-daemonst, then k8s will take care of deletion on its own.

https://github.com/up9inc/mizu/commit/5484b7c491993cd166fdeb33b5f9c742e21216b2 can be reverted with this PR.

Reading material:
- https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/