### PR TITLE
Don't statically link the CLI

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -22,7 +22,7 @@ build-debug:  ## Build mizu CLI for debug
 	${MAKE} build-base
 
 build:
-	export LDFLAGS_EXT='-extldflags=-static -s -w'
+	export LDFLAGS_EXT='-s -w'
 	${MAKE} build-base
 
 build-base: ## Build mizu CLI binary (select platform via GOOS / GOARCH env variables).


### PR DESCRIPTION
Introduced by the combination of:
- https://github.com/up9inc/mizu/pull/772
- https://github.com/up9inc/mizu/pull/754

Fixes the following error:

```
./cli/bin/mizu__ tap -n sock-shop                                                                                                                                                                                ok  19:16:09 
Mizu will store up to 200MB of traffic, old traffic will be cleared once the limit is reached.
Tapping pods in namespaces "sock-shop"
+carts-5fb6949d8c-cr4ts
+carts-db-6c6c68b747-sfns5
+catalogue-79fbdc774-rnfkr
+catalogue-db-96f6f6b4c-g7mg2
+front-end-5c89db9f57-j2fht
+kafka-0
+mizutest-amqp-py-bc8957cdf-cds5p
+mizutest-grpc-py-client-85c9bf7757-kn6tw
+mizutest-grpc-py-server-5947869cdf-4bj48
+mizutest-kafka-go-74b885d986-j6gsb
+mizutest-kafka-py-9bb4cbb7f-gpkqd
+mizutest-redis-go-6b8c9564c8-xfbj4
+orders-577f48897d-kcbnp
+orders-db-659949975f-gbh5z
+payment-679f96db7-cphl4
+queue-master-79dbb4496c-h6kjt
+rabbitmq-5bcbb547d7-jb75l
+session-db-7cf97f8d4f-5t9zc
+shipping-7787d9c9b-5xvtw
+user-754b9b548c-m95bp
+user-db-6df7444fc-vpxqx
+zookeeper-7b69697846-c77bj
Waiting for Mizu Agent to start...
Mizu is already running in this namespace, change the `mizu-resources-namespace` configuration or run `mizu clean` to remove the currently running Mizu instance
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x63 pc=0x7fc0e416e5ca]

runtime stack:
runtime.throw({0x1c36029, 0x7fbf94000d53})
	/usr/local/go/src/runtime/panic.go:1198 +0x71
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:719 +0x396

goroutine 76 [syscall]:
runtime.cgocall(0x16fc440, 0xc0004d0d90)
	/usr/local/go/src/runtime/cgocall.go:156 +0x5c fp=0xc0004d0d68 sp=0xc0004d0d30 pc=0x40541c
net._C2func_getaddrinfo(0xc0003612f0, 0x0, 0xc0006e4780, 0xc000010388)
	_cgo_gotypes.go:91 +0x56 fp=0xc0004d0d90 sp=0xc0004d0d68 pc=0x54d056
net.cgoLookupIPCNAME.func1({0xc0003612f0, 0x0, 0x0}, 0xc0003611c0, 0xc0004d0e50)
	/usr/local/go/src/net/cgo_unix.go:163 +0x9f fp=0xc0004d0de8 sp=0xc0004d0d90 pc=0x54ed9f
net.cgoLookupIPCNAME({0x1bf85d2, 0x3}, {0xc0003611c0, 0x5})
	/usr/local/go/src/net/cgo_unix.go:163 +0x16d fp=0xc0004d0f38 sp=0xc0004d0de8 pc=0x54e5ed
net.cgoIPLookup(0x2d43190, {0x1bf85d2, 0xc0003612e0}, {0xc0003611c0, 0xc0000e4370})
	/usr/local/go/src/net/cgo_unix.go:220 +0x3b fp=0xc0004d0fa8 sp=0xc0004d0f38 pc=0x54ee5b
net.cgoLookupIP·dwrap·25()
	/usr/local/go/src/net/cgo_unix.go:230 +0x36 fp=0xc0004d0fe0 sp=0xc0004d0fa8 pc=0x54f2d6
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc0004d0fe8 sp=0xc0004d0fe0 pc=0x466481
created by net.cgoLookupIP
	/usr/local/go/src/net/cgo_unix.go:230 +0x125

goroutine 1 [select]:
github.com/up9inc/mizu/cli/cmd.printNewVersionIfNeeded(0xc000044f60)
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/root.go:42 +0x96
github.com/up9inc/mizu/cli/cmd.Execute()
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/root.go:64 +0x1a8
reflect.Value.call({0x188d1e0, 0x1cdfe28, 0x445171}, {0x1bf88d0, 0x4}, {0x2d7c2b0, 0x0, 0x1bf1980})
	/usr/local/go/src/reflect/value.go:556 +0x845
reflect.Value.Call({0x188d1e0, 0x1cdfe28, 0x0}, {0x2d7c2b0, 0x0, 0x0})
	/usr/local/go/src/reflect/value.go:339 +0xc5
github.com/up9inc/mizu/cli/cmd/goUtils.HandleExcWrapper({0x188d1e0, 0x1cdfe28}, {0x0, 0x0, 0xc0000001a0})
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/goUtils/funcWrappers.go:25 +0x178
main.main()
	/home/mertyildiran/Documents/up9/mizu/cli/mizu.go:9 +0x2e

goroutine 6 [chan receive]:
k8s.io/klog/v2.(*loggingT).flushDaemon(0x0)
	/home/mertyildiran/go/pkg/mod/k8s.io/klog/v2@v2.40.1/klog.go:1283 +0x6a
created by k8s.io/klog/v2.init.0
	/home/mertyildiran/go/pkg/mod/k8s.io/klog/v2@v2.40.1/klog.go:420 +0xfb

goroutine 11 [select]:
net/http.(*Transport).getConn(0x2c66440, 0xc000712100, {{}, 0x0, {0xc0005cbf40, 0x5}, {0xc0003611c0, 0xe}, 0x0})
	/usr/local/go/src/net/http/transport.go:1372 +0x5d2
net/http.(*Transport).roundTrip(0x2c66440, 0xc0000d4400)
	/usr/local/go/src/net/http/transport.go:581 +0x774
net/http.(*Transport).RoundTrip(0xc000a07a28, 0x1e4e800)
	/usr/local/go/src/net/http/roundtrip.go:18 +0x19
net/http.send(0xc0000d4400, {0x1e4e800, 0x2c66440}, {0x1b99d40, 0x1, 0x0})
	/usr/local/go/src/net/http/client.go:252 +0x5d8
net/http.(*Client).send(0x2d43e20, 0xc0000d4400, {0xc0000d4400, 0x24, 0x0})
	/usr/local/go/src/net/http/client.go:176 +0x9b
net/http.(*Client).do(0x2d43e20, 0xc0000d4400)
	/usr/local/go/src/net/http/client.go:725 +0x908
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:593
net/http.(*Client).Get(0xc0001fc480, {0xc0005cbf40, 0xc0000420f0})
	/usr/local/go/src/net/http/client.go:480 +0x6a
net/http.Get(...)
	/usr/local/go/src/net/http/client.go:449
github.com/up9inc/mizu/cli/mizu/version.CheckNewerVersion(0x0)
	/home/mertyildiran/Documents/up9/mizu/cli/mizu/version/versionCheck.go:67 +0x205
created by github.com/up9inc/mizu/cli/cmd.Execute
	/home/mertyildiran/Documents/up9/mizu/cli/cmd/root.go:61 +0x175

goroutine 74 [select]:
net.(*Resolver).lookupIPAddr(0x2d43180, {0x1e80648, 0xc00043a300}, {0x1bf85d2, 0xc00056a050}, {0xc0003611c0, 0xa})
	/usr/local/go/src/net/lookup.go:302 +0x5c7
net.(*Resolver).internetAddrList(0x1e80648, {0x1e80648, 0xc00043a300}, {0x1bf85d2, 0x3}, {0xc0003611c0, 0xe})
	/usr/local/go/src/net/ipsock.go:288 +0x67a
net.(*Resolver).resolveAddrList(0x2d7c2b0, {0x1e80648, 0xc00043a300}, {0x1bf8cb0, 0x4}, {0x1bf85d2, 0x418ca6}, {0xc0003611c0, 0xe}, {0x0, ...})
	/usr/local/go/src/net/dial.go:221 +0x41b
net.(*Dialer).DialContext(0xc000054300, {0x1e80610, 0xc0000420f0}, {0x1bf85d2, 0x7fc0e422a180}, {0xc0003611c0, 0x118})
	/usr/local/go/src/net/dial.go:406 +0x448
net/http.(*Transport).dial(0x1b289c0, {0x1e80610, 0xc0000420f0}, {0x1bf85d2, 0x0}, {0xc0003611c0, 0x0})
	/usr/local/go/src/net/http/transport.go:1166 +0xda
net/http.(*Transport).dialConn(0x2c66440, {0x1e80610, 0xc0000420f0}, {{}, 0x0, {0xc0005cbf40, 0x5}, {0xc0003611c0, 0xe}, 0x0})
	/usr/local/go/src/net/http/transport.go:1604 +0x845
net/http.(*Transport).dialConnFor(0x12, 0xc0000e4370)
	/usr/local/go/src/net/http/transport.go:1446 +0xb0
created by net/http.(*Transport).queueForDial
	/usr/local/go/src/net/http/transport.go:1415 +0x3d7

goroutine 72 [IO wait]:
internal/poll.runtime_pollWait(0x7fc0e6babf30, 0x72)
	/usr/local/go/src/runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc0001d2180, 0xc000143000, 0x0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc0001d2180, {0xc000143000, 0xe03, 0xe03})
	/usr/local/go/src/internal/poll/fd_unix.go:167 +0x25a
net.(*netFD).Read(0xc0001d2180, {0xc000143000, 0x323, 0xc0003f6dc0})
	/usr/local/go/src/net/fd_posix.go:56 +0x29
net.(*conn).Read(0xc000720298, {0xc000143000, 0x6826f9, 0xc0005157f8})
	/usr/local/go/src/net/net.go:183 +0x45
crypto/tls.(*atLeastReader).Read(0xc0003f00a8, {0xc000143000, 0x0, 0x40baad})
	/usr/local/go/src/crypto/tls/conn.go:777 +0x3d
bytes.(*Buffer).ReadFrom(0xc0000bb078, {0x1e4bf60, 0xc0003f00a8})
	/usr/local/go/src/bytes/buffer.go:204 +0x98
crypto/tls.(*Conn).readFromUntil(0xc0000bae00, {0x1e4e700, 0xc000720298}, 0xc000143ae5)
	/usr/local/go/src/crypto/tls/conn.go:799 +0xe5
crypto/tls.(*Conn).readRecordOrCCS(0xc0000bae00, 0x0)
	/usr/local/go/src/crypto/tls/conn.go:606 +0x112
crypto/tls.(*Conn).readRecord(...)
	/usr/local/go/src/crypto/tls/conn.go:574
crypto/tls.(*Conn).Read(0xc0000bae00, {0xc00056c000, 0x1000, 0xc000500d00})
	/usr/local/go/src/crypto/tls/conn.go:1277 +0x16f
bufio.(*Reader).Read(0xc000391aa0, {0xc0004a3538, 0x9, 0xc0003e88a0})
	/usr/local/go/src/bufio/bufio.go:227 +0x1b4
io.ReadAtLeast({0x1e4bd00, 0xc000391aa0}, {0xc0004a3538, 0x9, 0x9}, 0x9)
	/usr/local/go/src/io/io.go:328 +0x9a
io.ReadFull(...)
	/usr/local/go/src/io/io.go:347
net/http.http2readFrameHeader({0xc0004a3538, 0x9, 0xc00063c150}, {0x1e4bd00, 0xc000391aa0})
	/usr/local/go/src/net/http/h2_bundle.go:1555 +0x6e
net/http.(*http2Framer).ReadFrame(0xc0004a3500)
	/usr/local/go/src/net/http/h2_bundle.go:1813 +0x95
net/http.(*http2clientConnReadLoop).run(0xc000515f98)
	/usr/local/go/src/net/http/h2_bundle.go:8608 +0x130
net/http.(*http2ClientConn).readLoop(0xc0001cea80)
	/usr/local/go/src/net/http/h2_bundle.go:8531 +0x6f
created by net/http.(*http2Transport).newClientConn
	/usr/local/go/src/net/http/h2_bundle.go:7325 +0xb85

goroutine 12 [select]:
k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop(0xc000390f00)
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/util/workqueue/delaying_queue.go:231 +0x34e
created by k8s.io/client-go/util/workqueue.newDelayingQueue
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/util/workqueue/delaying_queue.go:68 +0x247

goroutine 13 [chan receive]:
k8s.io/client-go/transport.(*dynamicClientCert).Run(0xc00032e640, 0xc000044cc0)
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/transport/cert_rotation.go:147 +0x335
created by k8s.io/client-go/transport.(*tlsTransportCache).get
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/transport/cache.go:104 +0x485

goroutine 50 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc00032e610, 0x1)
	/usr/local/go/src/runtime/sema.go:513 +0x13d
sync.(*Cond).Wait(0x1e6d8f0)
	/usr/local/go/src/sync/cond.go:56 +0x8c
k8s.io/client-go/util/workqueue.(*Type).Get(0xc000390de0)
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/util/workqueue/queue.go:157 +0x9e
k8s.io/client-go/transport.(*dynamicClientCert).processNextWorkItem(0xc00032e640)
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/transport/cert_rotation.go:156 +0x58
k8s.io/client-go/transport.(*dynamicClientCert).runWorker(...)
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/transport/cert_rotation.go:151
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x7fc0e4b0fc58)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:155 +0x67
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0, {0x1e4e1a0, 0xc00051a000}, 0x1, 0xc000044cc0)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0, 0x3b9aca00, 0x0, 0x0, 0x0)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(0x0, 0x0, 0x0)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:90 +0x25
created by k8s.io/client-go/transport.(*dynamicClientCert).Run
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/transport/cert_rotation.go:140 +0x26f

goroutine 51 [select]:
k8s.io/apimachinery/pkg/util/wait.WaitForWithContext({0x1e805d8, 0xc00061a000}, 0xc00061e000, 0x11d852a)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:658 +0xe7
k8s.io/apimachinery/pkg/util/wait.poll({0x1e805d8, 0xc00061a000}, 0x38, 0x11d75e5, 0xc00060e020)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:594 +0x9a
k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext({0x1e805d8, 0xc00061a000}, 0x0, 0x0)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:545 +0x49
k8s.io/apimachinery/pkg/util/wait.PollImmediateUntil(0x0, 0x0, 0x0)
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:536 +0x7c
created by k8s.io/client-go/transport.(*dynamicClientCert).Run
	/home/mertyildiran/go/pkg/mod/k8s.io/client-go@v0.23.3/transport/cert_rotation.go:142 +0x326

goroutine 52 [select]:
k8s.io/apimachinery/pkg/util/wait.contextForChannel.func1()
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:301 +0x77
created by k8s.io/apimachinery/pkg/util/wait.contextForChannel
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:300 +0xc8

goroutine 53 [select]:
k8s.io/apimachinery/pkg/util/wait.poller.func1.1()
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:708 +0x1c9
created by k8s.io/apimachinery/pkg/util/wait.poller.func1
	/home/mertyildiran/go/pkg/mod/k8s.io/apimachinery@v0.23.3/pkg/util/wait/wait.go:691 +0xcf

goroutine 75 [select]:
net.cgoLookupIP({0x1e805d8, 0xc000712140}, {0x1bf85d2, 0xa}, {0xc0003611c0, 0xc0001cea80})
	/usr/local/go/src/net/cgo_unix.go:231 +0x1b7
net.(*Resolver).lookupIP(0x2d43180, {0x1e805d8, 0xc000712140}, {0x1bf85d2, 0x3}, {0xc0003611c0, 0xa})
	/usr/local/go/src/net/lookup_unix.go:97 +0x128
net.glob..func1({0x1e805d8, 0xc000712140}, 0x0, {0x1bf85d2, 0x0}, {0xc0003611c0, 0x74d290})
	/usr/local/go/src/net/hook.go:23 +0x3d
net.(*Resolver).lookupIPAddr.func1()
	/usr/local/go/src/net/lookup.go:296 +0x9f
internal/singleflight.(*Group).doCall(0x2d43190, 0xc00056a0a0, {0xc0003612e0, 0xe}, 0xc0000e4370)
	/usr/local/go/src/internal/singleflight/singleflight.go:95 +0x3b
created by internal/singleflight.(*Group).DoChan
	/usr/local/go/src/internal/singleflight/singleflight.go:88 +0x2f1

goroutine 67 [IO wait]:
internal/poll.runtime_pollWait(0x7fc0e6bac018, 0x72)
	/usr/local/go/src/runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc0002f6080, 0xc000760000, 0x0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc0002f6080, {0xc000760000, 0x728c, 0x728c})
	/usr/local/go/src/internal/poll/fd_unix.go:167 +0x25a
net.(*netFD).Read(0xc0002f6080, {0xc000760000, 0x7287, 0xc00073d260})
	/usr/local/go/src/net/fd_posix.go:56 +0x29
net.(*conn).Read(0xc000720018, {0xc000760000, 0xc000760000, 0x5})
	/usr/local/go/src/net/net.go:183 +0x45
crypto/tls.(*atLeastReader).Read(0xc00000faa0, {0xc000760000, 0x0, 0x40baad})
	/usr/local/go/src/crypto/tls/conn.go:777 +0x3d
bytes.(*Buffer).ReadFrom(0xc0000bacf8, {0x1e4bf60, 0xc00000faa0})
	/usr/local/go/src/bytes/buffer.go:204 +0x98
crypto/tls.(*Conn).readFromUntil(0xc0000baa80, {0x7fc0e4019ad8, 0xc00037a150}, 0x728c)
	/usr/local/go/src/crypto/tls/conn.go:799 +0xe5
crypto/tls.(*Conn).readRecordOrCCS(0xc0000baa80, 0x0)
	/usr/local/go/src/crypto/tls/conn.go:606 +0x112
crypto/tls.(*Conn).readRecord(...)
	/usr/local/go/src/crypto/tls/conn.go:574
crypto/tls.(*Conn).Read(0xc0000baa80, {0xc0001c4000, 0x1000, 0x91ad80})
	/usr/local/go/src/crypto/tls/conn.go:1277 +0x16f
bufio.(*Reader).Read(0xc0003e96e0, {0xc0001d82e0, 0x9, 0x928d42})
	/usr/local/go/src/bufio/bufio.go:227 +0x1b4
io.ReadAtLeast({0x1e4bd00, 0xc0003e96e0}, {0xc0001d82e0, 0x9, 0x9}, 0x9)
	/usr/local/go/src/io/io.go:328 +0x9a
io.ReadFull(...)
	/usr/local/go/src/io/io.go:347
golang.org/x/net/http2.readFrameHeader({0xc0001d82e0, 0x9, 0xc00169d470}, {0x1e4bd00, 0xc0003e96e0})
	/home/mertyildiran/go/pkg/mod/golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/frame.go:237 +0x6e
golang.org/x/net/http2.(*Framer).ReadFrame(0xc0001d82a0)
	/home/mertyildiran/go/pkg/mod/golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/frame.go:498 +0x95
golang.org/x/net/http2.(*clientConnReadLoop).run(0xc000595f98)
	/home/mertyildiran/go/pkg/mod/golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:2101 +0x130
golang.org/x/net/http2.(*ClientConn).readLoop(0xc00046c300)
	/home/mertyildiran/go/pkg/mod/golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:1997 +0x6f
created by golang.org/x/net/http2.(*Transport).newClientConn
	/home/mertyildiran/go/pkg/mod/golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:725 +0xac5
```