### PR TITLE
Update relase template for Mac M1 executable

### DIFF
--- a/cli/README.md.TEMPLATE
+++ b/cli/README.md.TEMPLATE
@@ -10,7 +10,7 @@ curl -Lo mizu https://github.com/up9inc/mizu/releases/download/_VER_/mizu_darwin
 
 **Mac** (AArch64/Apple M1 silicon)
 ```
-rm mizu && curl -Lo mizu https://github.com/up9inc/mizu/releases/download/_VER_/mizu_darwin_arm64 && chmod 755 mizu
+rm -f mizu && curl -Lo mizu https://github.com/up9inc/mizu/releases/download/_VER_/mizu_darwin_arm64 && chmod 755 mizu
 ```
 
 **Linux** (x86-64)

--- a/cli/README.md.TEMPLATE
+++ b/cli/README.md.TEMPLATE
@@ -10,7 +10,7 @@ curl -Lo mizu https://github.com/up9inc/mizu/releases/download/_VER_/mizu_darwin
 
 **Mac** (AArch64/Apple M1 silicon)
 ```
-curl -Lo mizu https://github.com/up9inc/mizu/releases/download/_VER_/mizu_darwin_arm64 && chmod 755 mizu
+rm mizu && curl -Lo mizu https://github.com/up9inc/mizu/releases/download/_VER_/mizu_darwin_arm64 && chmod 755 mizu
 ```
 
 **Linux** (x86-64)


### PR DESCRIPTION

This should fix this issue:
![image (5)](https://user-images.githubusercontent.com/9381637/154934174-f3a06c4d-2ec0-46c1-a6ab-f966535d97bf.png)

On Mac M1 if you override the executable the OS refuse to execute and will kill it because of caching mechanism