### PR TITLE
OAS: Recluster endpoints where possible

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/antelman107/net-wait-go v0.0.0-20210623112055-cf684aebda7b
-	github.com/chanced/openapi v0.0.7
+	github.com/chanced/openapi v0.0.8
 	github.com/djherbis/atime v1.1.0
 	github.com/elastic/go-elasticsearch/v7 v7.17.0
 	github.com/getkin/kin-openapi v0.89.0

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -132,8 +132,8 @@ github.com/chanced/cmpjson v0.0.0-20210415035445-da9262c1f20a/go.mod h1:yhcmlFk1
 github.com/chanced/dynamic v0.0.0-20210502140838-c010b5fc3e44/go.mod h1:XVNfXN5kgZST4PQ0W/oBAHJku2OteCeHxjAbvfd0ARM=
 github.com/chanced/dynamic v0.0.0-20211210164248-f8fadb1d735b h1:nQWfVfhByCAYUjDxWNMyMtq3VZ8AGOxF7wZlDnC5cTc=
 github.com/chanced/dynamic v0.0.0-20211210164248-f8fadb1d735b/go.mod h1:XVNfXN5kgZST4PQ0W/oBAHJku2OteCeHxjAbvfd0ARM=
-github.com/chanced/openapi v0.0.7 h1:OmOBHCg/5ViUg0gaGxXBeEFoVBE8C2pHK4BO/AiD6k8=
-github.com/chanced/openapi v0.0.7/go.mod h1:SxE2VMLPw+T7Vq8nwbVVhDF2PigvRF4n5XyqsVpRJGU=
+github.com/chanced/openapi v0.0.8 h1:pOqKTvZEET2odGE+kJBrAdXvgpTKFPk+XRz5NTuMvrM=
+github.com/chanced/openapi v0.0.8/go.mod h1:SxE2VMLPw+T7Vq8nwbVVhDF2PigvRF4n5XyqsVpRJGU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/agent/pkg/oas/specgen_test.go
+++ b/agent/pkg/oas/specgen_test.go
@@ -171,14 +171,15 @@ func TestFileSingle(t *testing.T) {
 			t.FailNow()
 		}
 
+		if os.Getenv("MIZU_OAS_WRITE_FILES") != "" {
+			err = ioutil.WriteFile(file+".spec.json", []byte(specText), 0644)
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		if len(diff) > 0 {
 			t.Errorf("Generated spec does not match expected:\n%s", diff.String())
-			if os.Getenv("MIZU_OAS_WRITE_FILES") != "" {
-				err = ioutil.WriteFile(file+".spec.json", []byte(specText), 0644)
-				if err != nil {
-					panic(err)
-				}
-			}
 		}
 
 		return true

--- a/agent/pkg/oas/test_artifacts/params.har.spec.json
+++ b/agent/pkg/oas/test_artifacts/params.har.spec.json
@@ -36,8 +36,6 @@
             "sumDuration": 0
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750580.04,
         "x-counters-total": {
           "entries": 1,
           "failures": 0,
@@ -45,7 +43,9 @@
           "lastSeen": 1567750580.04,
           "sumRT": 0.63,
           "sumDuration": 0
-        }
+        },
+        "x-last-seen-ts": 1567750580.04,
+        "x-sample-entry": 0
       }
     },
     "/appears-twice": {
@@ -63,16 +63,6 @@
             }
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750581.74,
-        "x-counters-total": {
-          "entries": 2,
-          "failures": 0,
-          "firstSeen": 1567750580.74,
-          "lastSeen": 1567750581.74,
-          "sumRT": 1.26,
-          "sumDuration": 1
-        },
         "x-counters-per-source": {
           "": {
             "entries": 2,
@@ -82,7 +72,17 @@
             "sumRT": 1.26,
             "sumDuration": 1
           }
-        }
+        },
+        "x-counters-total": {
+          "entries": 2,
+          "failures": 0,
+          "firstSeen": 1567750580.74,
+          "lastSeen": 1567750581.74,
+          "sumRT": 1.26,
+          "sumDuration": 1
+        },
+        "x-last-seen-ts": 1567750581.74,
+        "x-sample-entry": 0
       }
     },
     "/body-optional": {
@@ -98,16 +98,6 @@
             }
           }
         },
-        "x-sample-entry": 0,
-        "x-counters-total": {
-          "entries": 3,
-          "failures": 0,
-          "firstSeen": 1567750581.74,
-          "lastSeen": 1567750581.75,
-          "sumRT": 0.00,
-          "sumDuration": 0.01
-        },
-        "x-last-seen-ts": 1567750581.75,
         "x-counters-per-source": {
           "": {
             "entries": 3,
@@ -118,6 +108,16 @@
             "sumDuration": 0.01
           }
         },
+        "x-counters-total": {
+          "entries": 3,
+          "failures": 0,
+          "firstSeen": 1567750581.74,
+          "lastSeen": 1567750581.75,
+          "sumRT": 0.00,
+          "sumDuration": 0.01
+        },
+        "x-last-seen-ts": 1567750581.75,
+        "x-sample-entry": 0,
         "requestBody": {
           "description": "Generic request body",
           "content": {
@@ -141,15 +141,6 @@
             }
           }
         },
-        "x-sample-entry": 0,
-        "x-counters-total": {
-          "entries": 1,
-          "failures": 0,
-          "firstSeen": 1567750581.75,
-          "lastSeen": 1567750581.75,
-          "sumRT": 0.00,
-          "sumDuration": 0
-        },
         "x-counters-per-source": {
           "": {
             "entries": 1,
@@ -160,7 +151,16 @@
             "sumDuration": 0
           }
         },
+        "x-counters-total": {
+          "entries": 1,
+          "failures": 0,
+          "firstSeen": 1567750581.75,
+          "lastSeen": 1567750581.75,
+          "sumRT": 0.00,
+          "sumDuration": 0
+        },
         "x-last-seen-ts": 1567750581.75,
+        "x-sample-entry": 0,
         "requestBody": {
           "description": "Generic request body",
           "content": {
@@ -187,16 +187,6 @@
             }
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750582.74,
-        "x-counters-total": {
-          "entries": 1,
-          "failures": 0,
-          "firstSeen": 1567750582.74,
-          "lastSeen": 1567750582.74,
-          "sumRT": 0.00,
-          "sumDuration": 0
-        },
         "x-counters-per-source": {
           "": {
             "entries": 1,
@@ -207,6 +197,16 @@
             "sumDuration": 0
           }
         },
+        "x-counters-total": {
+          "entries": 1,
+          "failures": 0,
+          "firstSeen": 1567750582.74,
+          "lastSeen": 1567750582.74,
+          "sumRT": 0.00,
+          "sumDuration": 0
+        },
+        "x-last-seen-ts": 1567750582.74,
+        "x-sample-entry": 0,
         "requestBody": {
           "description": "Generic request body",
           "content": {
@@ -263,8 +263,6 @@
             "sumDuration": 1
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750581.74,
         "x-counters-total": {
           "entries": 2,
           "failures": 0,
@@ -273,6 +271,8 @@
           "sumRT": 0.00,
           "sumDuration": 1
         },
+        "x-last-seen-ts": 1567750581.74,
+        "x-sample-entry": 0,
         "requestBody": {
           "description": "Generic request body",
           "content": {
@@ -345,8 +345,6 @@
             "sumDuration": 9.53e-7
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750582.00,
         "x-counters-total": {
           "entries": 2,
           "failures": 0,
@@ -354,7 +352,9 @@
           "lastSeen": 1567750582.00,
           "sumRT": 0.00,
           "sumDuration": 9.53e-7
-        }
+        },
+        "x-last-seen-ts": 1567750582.00,
+        "x-sample-entry": 0
       },
       "parameters": [
         {
@@ -402,15 +402,6 @@
             }
           }
         },
-        "x-last-seen-ts": 1567750582.00,
-        "x-counters-total": {
-          "entries": 1,
-          "failures": 0,
-          "firstSeen": 1567750582.00,
-          "lastSeen": 1567750582.00,
-          "sumRT": 0.00,
-          "sumDuration": 0
-        },
         "x-counters-per-source": {
           "": {
             "entries": 1,
@@ -421,6 +412,15 @@
             "sumDuration": 0
           }
         },
+        "x-counters-total": {
+          "entries": 1,
+          "failures": 0,
+          "firstSeen": 1567750582.00,
+          "lastSeen": 1567750582.00,
+          "sumRT": 0.00,
+          "sumDuration": 0
+        },
+        "x-last-seen-ts": 1567750582.00,
         "x-sample-entry": 0
       },
       "parameters": [
@@ -479,8 +479,6 @@
             "sumDuration": 0
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750582.00,
         "x-counters-total": {
           "entries": 1,
           "failures": 0,
@@ -488,7 +486,9 @@
           "lastSeen": 1567750582.00,
           "sumRT": 0.00,
           "sumDuration": 0
-        }
+        },
+        "x-last-seen-ts": 1567750582.00,
+        "x-sample-entry": 0
       },
       "parameters": [
         {
@@ -536,14 +536,6 @@
             }
           }
         },
-        "x-counters-total": {
-          "entries": 1,
-          "failures": 0,
-          "firstSeen": 1567750582.00,
-          "lastSeen": 1567750582.00,
-          "sumRT": 0.00,
-          "sumDuration": 0
-        },
         "x-counters-per-source": {
           "": {
             "entries": 1,
@@ -554,8 +546,16 @@
             "sumDuration": 0
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750582.00
+        "x-counters-total": {
+          "entries": 1,
+          "failures": 0,
+          "firstSeen": 1567750582.00,
+          "lastSeen": 1567750582.00,
+          "sumRT": 0.00,
+          "sumDuration": 0
+        },
+        "x-last-seen-ts": 1567750582.00,
+        "x-sample-entry": 0
       },
       "parameters": [
         {
@@ -616,15 +616,6 @@
             }
           }
         },
-        "x-last-seen-ts": 1567750579.74,
-        "x-counters-total": {
-          "entries": 1,
-          "failures": 0,
-          "firstSeen": 1567750579.74,
-          "lastSeen": 1567750579.74,
-          "sumRT": 0.63,
-          "sumDuration": 0
-        },
         "x-counters-per-source": {
           "": {
             "entries": 1,
@@ -635,6 +626,15 @@
             "sumDuration": 0
           }
         },
+        "x-counters-total": {
+          "entries": 1,
+          "failures": 0,
+          "firstSeen": 1567750579.74,
+          "lastSeen": 1567750579.74,
+          "sumRT": 0.63,
+          "sumDuration": 0
+        },
+        "x-last-seen-ts": 1567750579.74,
         "x-sample-entry": 0
       },
       "parameters": [
@@ -670,16 +670,6 @@
             }
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750483.86,
-        "x-counters-total": {
-          "entries": 1,
-          "failures": 0,
-          "firstSeen": 1567750483.86,
-          "lastSeen": 1567750483.86,
-          "sumRT": 0.11,
-          "sumDuration": 0
-        },
         "x-counters-per-source": {
           "": {
             "entries": 1,
@@ -689,7 +679,17 @@
             "sumRT": 0.11,
             "sumDuration": 0
           }
-        }
+        },
+        "x-counters-total": {
+          "entries": 1,
+          "failures": 0,
+          "firstSeen": 1567750483.86,
+          "lastSeen": 1567750483.86,
+          "sumRT": 0.11,
+          "sumDuration": 0
+        },
+        "x-last-seen-ts": 1567750483.86,
+        "x-sample-entry": 0
       },
       "parameters": [
         {
@@ -726,16 +726,6 @@
             }
           }
         },
-        "x-sample-entry": 0,
-        "x-last-seen-ts": 1567750578.74,
-        "x-counters-total": {
-          "entries": 1,
-          "failures": 0,
-          "firstSeen": 1567750578.74,
-          "lastSeen": 1567750578.74,
-          "sumRT": 0.63,
-          "sumDuration": 0
-        },
         "x-counters-per-source": {
           "": {
             "entries": 1,
@@ -745,7 +735,17 @@
             "sumRT": 0.63,
             "sumDuration": 0
           }
-        }
+        },
+        "x-counters-total": {
+          "entries": 1,
+          "failures": 0,
+          "firstSeen": 1567750578.74,
+          "lastSeen": 1567750578.74,
+          "sumRT": 0.63,
+          "sumDuration": 0
+        },
+        "x-last-seen-ts": 1567750578.74,
+        "x-sample-entry": 0
       },
       "parameters": [
         {
@@ -768,14 +768,6 @@
       ]
     }
   },
-  "x-counters-total": {
-    "entries": 18,
-    "failures": 0,
-    "firstSeen": 1567750483.86,
-    "lastSeen": 1567750582.74,
-    "sumRT": 3.27,
-    "sumDuration": 2.01
-  },
   "x-counters-per-source": {
     "": {
       "entries": 18,
@@ -785,5 +777,13 @@
       "sumRT": 3.27,
       "sumDuration": 2.01
     }
+  },
+  "x-counters-total": {
+    "entries": 18,
+    "failures": 0,
+    "firstSeen": 1567750483.86,
+    "lastSeen": 1567750582.74,
+    "sumRT": 3.27,
+    "sumDuration": 2.01
   }
 }


### PR DESCRIPTION
If we learned over time sufficient information to group endpoints together - do it. 
Remember historical OperationIDs into custom property.