### PR TITLE
Build custom branch Github action

### DIFF
--- a/.github/workflows/build-custom-branch.yml
+++ b/.github/workflows/build-custom-branch.yml
@@ -52,8 +52,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             TARGETARCH=${{ matrix.target }}
             VER=${{ steps.versioning.outputs.version }}

--- a/.github/workflows/build-custom-branch.yml
+++ b/.github/workflows/build-custom-branch.yml
@@ -24,20 +24,6 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
 
-      - name: Get base image name
-        shell: bash
-        run: echo "##[set-output name=image;]$(echo gcr.io/up9-docker-hub/mizu/${GITHUB_REF#refs/heads/})"
-        id: base_image_step
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ${{ steps.base_image_step.outputs.image }}
-          tags: |
-            type=raw,value=latest
-
       - name: Login to GCR
         uses: docker/login-action@v1
         with:
@@ -50,11 +36,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            TARGETARCH=${{ matrix.target }}
-            VER=${{ steps.versioning.outputs.version }}
-            BUILD_TIMESTAMP=${{ steps.version_parameters.outputs.build_timestamp }}
-            GIT_BRANCH=${{ steps.version_parameters.outputs.branch }}
-            COMMIT_HASH=${{ github.sha }}
+          tags: gcr.io/up9-docker-hub/mizu/${GITHUB_REF#refs/heads/}:latest

--- a/.github/workflows/build-custom-branch.yml
+++ b/.github/workflows/build-custom-branch.yml
@@ -1,0 +1,66 @@
+name: Build Custom Branch
+
+on: push
+
+concurrency:
+  group: custom-branch-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Push Docker image to GCR
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.head_commit.message, '#build_and_publish_custom_image') }}
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCR_JSON_KEY }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
+
+      - name: Get base image name
+        shell: bash
+        run: echo "##[set-output name=image;]$(echo gcr.io/up9-docker-hub/mizu/${GITHUB_REF#refs/heads/})"
+        id: base_image_step
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ steps.base_image_step.outputs.image }}
+          tags: |
+            type=raw,value=latest
+
+      - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GCR_JSON_KEY }}
+
+      - name: Set up Docker Buildx
+        if: steps.modified_files.outputs.matched == 'true'
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            TARGETARCH=${{ matrix.target }}
+            VER=${{ steps.versioning.outputs.version }}
+            BUILD_TIMESTAMP=${{ steps.version_parameters.outputs.build_timestamp }}
+            GIT_BRANCH=${{ steps.version_parameters.outputs.branch }}
+            COMMIT_HASH=${{ github.sha }}

--- a/.github/workflows/build-custom-branch.yml
+++ b/.github/workflows/build-custom-branch.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    name: Push Docker image to GCR
+    name: Push custom branch image to GCR
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.head_commit.message, '#build_and_publish_custom_image') }}
 

--- a/.github/workflows/build-custom-branch.yml
+++ b/.github/workflows/build-custom-branch.yml
@@ -24,6 +24,11 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
 
+      - name: Get base image name
+        shell: bash
+        run: echo "##[set-output name=image;]$(echo gcr.io/up9-docker-hub/mizu/${GITHUB_REF#refs/heads/})"
+        id: base_image_step
+
       - name: Login to GCR
         uses: docker/login-action@v1
         with:
@@ -36,4 +41,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: gcr.io/up9-docker-hub/mizu/${GITHUB_REF#refs/heads/}:latest
+          tags: ${{ steps.base_image_step.outputs.image }}:latest

--- a/.github/workflows/build-custom-branch.yml
+++ b/.github/workflows/build-custom-branch.yml
@@ -45,9 +45,6 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-custom-branch.yml
+++ b/.github/workflows/build-custom-branch.yml
@@ -46,7 +46,6 @@ jobs:
           password: ${{ secrets.GCR_JSON_KEY }}
 
       - name: Set up Docker Buildx
-        if: steps.modified_files.outputs.matched == 'true'
         uses: docker/setup-buildx-action@v1
 
       - name: Build and push


### PR DESCRIPTION
Currently developer with Mac M1 can't build Mizu docker image for AMD Architecture.
This is a workaround for now for these developers to build a custom docker image for testing

The build is triggered with '#build_and_publish_custom_image' in commit message, and will be published to gcr.io/up9-docker-hub/mizu/<branch name>:latest