### PR TITLE
Make `EntryTitle` component responsive

### DIFF
--- a/ui-common/src/components/TrafficViewer/EntryDetailed.tsx
+++ b/ui-common/src/components/TrafficViewer/EntryDetailed.tsx
@@ -11,6 +11,7 @@ import trafficViewerApi from "../../recoil/TrafficViewerApi";
 import TrafficViewerApi from "./TrafficViewerApi";
 import TrafficViewerApiAtom from "../../recoil/TrafficViewerApi/atom";
 import queryAtom from "../../recoil/query/atom";
+import useWindowDimensions from "./WindowDimensionsHook";
 
 const useStyles = makeStyles(() => ({
     entryTitle: {
@@ -41,9 +42,24 @@ const EntryTitle: React.FC<any> = ({protocol, data, elapsedTime}) => {
     const request = data.request;
     const response = data.response;
 
+    const { width } = useWindowDimensions();
+    let requestText = "Request: "
+    let responseText = "Response: "
+    let elapsedTimeText = "Elapsed Time: "
+
+    if (width < 1078) {
+        requestText = ""
+        responseText = ""
+        elapsedTimeText = ""
+    } else if (width < 1356) {
+        requestText = "Req: "
+        responseText = "Res: "
+        elapsedTimeText = "ET: "
+    }
+
     return <div className={classes.entryTitle}>
         <Protocol protocol={protocol} horizontal={true}/>
-        <div style={{right: "30px", position: "absolute", display: "flex"}}>
+        {width > 880 && <div style={{right: "30px", position: "absolute", display: "flex"}}>
             {request && <Queryable
                 query={`requestSize == ${data.requestSize}`}
                 style={{margin: "0 18px"}}
@@ -53,7 +69,7 @@ const EntryTitle: React.FC<any> = ({protocol, data, elapsedTime}) => {
                     style={{opacity: 0.5}}
                     id="entryDetailedTitleRequestSize"
                 >
-                    {`Request: ${formatSize(data.requestSize)}`}
+                    {`${requestText}${formatSize(data.requestSize)}`}
                 </div>
             </Queryable>}
             {response && <Queryable
@@ -65,22 +81,22 @@ const EntryTitle: React.FC<any> = ({protocol, data, elapsedTime}) => {
                     style={{opacity: 0.5}}
                     id="entryDetailedTitleResponseSize"
                 >
-                    {`Response: ${formatSize(data.responseSize)}`}
+                    {`${responseText}${formatSize(data.responseSize)}`}
                 </div>
             </Queryable>}
             {response && <Queryable
                 query={`elapsedTime >= ${elapsedTime}`}
-                style={{marginRight: 18}}
+                style={{margin: "0 0 0 18px"}}
                 displayIconOnMouseOver={true}
             >
                 <div
                     style={{opacity: 0.5}}
                     id="entryDetailedTitleElapsedTime"
                 >
-                    {`Elapsed Time: ${Math.round(elapsedTime)}ms`}
+                    {`${elapsedTimeText}${Math.round(elapsedTime)}ms`}
                 </div>
             </Queryable>}
-        </div>
+        </div>}
     </div>;
 };
 

--- a/ui-common/src/components/TrafficViewer/WindowDimensionsHook.tsx
+++ b/ui-common/src/components/TrafficViewer/WindowDimensionsHook.tsx
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+function getWindowDimensions() {
+    const { innerWidth: width, innerHeight: height } = window;
+    return {
+        width,
+        height
+    };
+}
+
+export default function useWindowDimensions() {
+    const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+    useEffect(() => {
+    function handleResize() {
+        setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return windowDimensions;
+}


### PR DESCRIPTION
### Before

![Screenshot from 2022-03-23 19-25-17](https://user-images.githubusercontent.com/2502080/159748298-7f0c4dd3-bccd-42e2-ab06-3f4ab68caf11.png)

### After

![Screenshot from 2022-03-23 19-21-33](https://user-images.githubusercontent.com/2502080/159748370-6f8a2720-50b5-4318-8831-2c2c06581d8b.png)
![Screenshot from 2022-03-23 19-21-38](https://user-images.githubusercontent.com/2502080/159748379-c99b0eec-69c0-4979-b836-c811431337f7.png)
![Screenshot from 2022-03-23 19-21-45](https://user-images.githubusercontent.com/2502080/159748384-c22c3114-492d-430c-b23d-afd01cac2af4.png)
![Screenshot from 2022-03-23 19-21-50](https://user-images.githubusercontent.com/2502080/159748387-655e6018-a738-422e-8a3e-7f060b8f8adf.png)


