### PR TITLE
Set the entry namespace to the source namespace if the destination is not resolved

### DIFF
--- a/agent/pkg/api/main.go
+++ b/agent/pkg/api/main.go
@@ -196,7 +196,10 @@ func resolveIP(connectionInfo *tapApi.ConnectionInfo) (resolvedSource string, re
 		} else {
 			resolvedDestination = resolvedDestinationObject.FullAddress
 			// Overwrite namespace (if it was set according to the source)
-			namespace = resolvedDestinationObject.Namespace
+			// Only overwrite if non-empty
+			if resolvedDestinationObject.Namespace != "" {
+				namespace = resolvedDestinationObject.Namespace
+			}
 		}
 	}
 	return resolvedSource, resolvedDestination, namespace

--- a/agent/pkg/api/main.go
+++ b/agent/pkg/api/main.go
@@ -183,6 +183,7 @@ func resolveIP(connectionInfo *tapApi.ConnectionInfo) (resolvedSource string, re
 			}
 		} else {
 			resolvedSource = resolvedSourceObject.FullAddress
+			namespace = resolvedSourceObject.Namespace
 		}
 
 		unresolvedDestination := fmt.Sprintf("%s:%s", connectionInfo.ServerIP, connectionInfo.ServerPort)
@@ -194,6 +195,7 @@ func resolveIP(connectionInfo *tapApi.ConnectionInfo) (resolvedSource string, re
 			}
 		} else {
 			resolvedDestination = resolvedDestinationObject.FullAddress
+			// Overwrite namespace (if it was set according to the source)
 			namespace = resolvedDestinationObject.Namespace
 		}
 	}


### PR DESCRIPTION
Prior to this PR Mizu sets the entry namespace to the namespace of the resolved destination.
However, sometimes the destination is not resolved while the source is. For instance, when the destination is an external address.

This PR adds the following logic:
If the destination is resolved and the namespace is not empty, use it.
Otherwise, if the source is resolved then use its namespace.

This change allows filtering by namespace to include entries which were previously left out unintentionally. The namespace  of a source is of interest to a user. 

Unhandled cases:
1. If both source and destination are resolved, then only the destination namespace is taken into account. A better solution would be to maintain two separate fields in the DB: source namespace and destination namespace.
2. Only Services are resolved. Traffic from Pods which are not exposed via a Service (Deployments/DaemonSets or even standalone Pods) won't have a namespace. This is a caveat of the name resolving implementation. The immediate ramification is that a client pod targeting an external service won't show in the Enterprise UI at all. We can avoid by falling back to pod-name-based resolution.

Suggested improvements:
1. In TLS tapper we know the namespace of the tapped pod (sometimes source and sometimes dest) even before IP resolving. We know it from the CGROUP to which the pod belongs. We can use it even if resolving fails. (question: Should we use it as src/dst or as a separate field "tapped namespace"?)