### PR TITLE
Format commit message as code to handle multi line messages

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           status: ${{ job.status }}
           notification_title: 'Mizu {workflow} has {status_message}'
-          message_format: '{emoji} *{workflow}* {status_message} during <{run_url}|run>, after commit <{commit_url}|{commit_sha} ${{ github.event.head_commit.message }}> ${{ github.event.head_commit.committer.name }} <${{ github.event.head_commit.committer.email }}>'
+          message_format: '{emoji} *{workflow}* {status_message} during <{run_url}|run>, after commit <{commit_url}|{commit_sha}> by ${{ github.event.head_commit.committer.name }} <${{ github.event.head_commit.committer.email }}> ```${{ github.event.head_commit.message }}```'
           footer: 'Linked Repo <{repo_url}|{repo}>'
           notify_when: 'failure'
         env:


### PR DESCRIPTION
Multi line commit messages break the slack message formatting. This PR fixes by formatting the commit message as `code`.

Before:
![image](https://user-images.githubusercontent.com/59927337/161433095-a4f01bfb-70d6-434d-9b64-691e9db0c6ac.png)

After:
![image](https://user-images.githubusercontent.com/59927337/161433007-9f697b38-972d-4c9f-a08f-b021bd74704e.png)