### PR TITLE
Handle `reflect.TypeOf` returning `nil` case

### DIFF
--- a/tap/extensions/http/helpers.go
+++ b/tap/extensions/http/helpers.go
@@ -53,7 +53,16 @@ func representMapSliceAsTable(mapSlice []interface{}, selectorPrefix string) (re
 		h := item.(map[string]interface{})
 		key := h["name"].(string)
 		value := h["value"]
-		switch reflect.TypeOf(value).Kind() {
+
+		var reflectKind reflect.Kind
+		reflectType := reflect.TypeOf(value)
+		if reflectType == nil {
+			reflectKind = reflect.Interface
+		} else {
+			reflectKind = reflect.TypeOf(value).Kind()
+		}
+
+		switch reflectKind {
 		case reflect.Slice:
 			fallthrough
 		case reflect.Array:


### PR DESCRIPTION
`reflect.TypeOf(value)` was returning `nil` in cases of `value` is `nil`. That was causing the error below:

```
mizu-api-server mizu-api-server 2022/04/04 12:42:15 [Recovery] 2022/04/04 - 12:42:15 panic recovered:
mizu-api-server mizu-api-server runtime error: invalid memory address or nil pointer dereference
mizu-api-server mizu-api-server /usr/local/go/src/runtime/panic.go:221 (0x44c746)
mizu-api-server mizu-api-server /usr/local/go/src/runtime/signal_unix.go:735 (0x44c716)
mizu-api-server mizu-api-server /app/tap/extensions/http/helpers.go:56 (0x1b5509c)
...
```

The PR fixes it.