### PR TITLE
Remove cluster.local hostnames

### DIFF
--- a/shared/kubernetes/mizuTapperSyncer.go
+++ b/shared/kubernetes/mizuTapperSyncer.go
@@ -329,7 +329,7 @@ func (tapperSyncer *MizuTapperSyncer) updateMizuTappers() error {
 			TapperDaemonSetName,
 			tapperSyncer.config.AgentImage,
 			TapperPodName,
-			fmt.Sprintf("%s.%s.svc.cluster.local", ApiServerPodName, tapperSyncer.config.MizuResourcesNamespace),
+			fmt.Sprintf("%s.%s.svc", ApiServerPodName, tapperSyncer.config.MizuResourcesNamespace),
 			nodeNames,
 			serviceAccountName,
 			tapperSyncer.config.TapperResources,


### PR DESCRIPTION
This change will enable using mizu on clusters with custom names different than cluster.local.