### PR TITLE
Feature/reorginize some tls code after refactor

### DIFF
--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -413,22 +413,15 @@ type TcpReader interface {
 	GetReqResMatcher() RequestResponseMatcher
 	GetIsClient() bool
 	GetReadProgress() *ReadProgress
-	GetParent() TcpStream
 	GetTcpID() *TcpID
 	GetCounterPair() *CounterPair
 	GetCaptureTime() time.Time
 	GetEmitter() Emitter
 	GetIsClosed() bool
 	GetExtension() *Extension
-}
-
-type TcpStream interface {
 	SetProtocol(protocol *Protocol)
-	GetOrigin() Capture
 	GetProtoIdentifier() *ProtoIdentifier
-	GetReqResMatcher() RequestResponseMatcher
-	GetIsTapTarget() bool
-	GetIsClosed() bool
+	GetOrigin() Capture
 }
 
 type TcpStreamMap interface {

--- a/tap/cleaner.go
+++ b/tap/cleaner.go
@@ -34,7 +34,7 @@ func (cl *Cleaner) clean() {
 	cl.assemblerMutex.Unlock()
 
 	cl.streamsMap.Range(func(k, v interface{}) bool {
-		reqResMatcher := v.(api.TcpStream).GetReqResMatcher()
+		reqResMatcher := v.(*tcpStream).GetReqResMatcher()
 		if reqResMatcher == nil {
 			return true
 		}

--- a/tap/extensions/amqp/main.go
+++ b/tap/extensions/amqp/main.go
@@ -75,7 +75,7 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 	var lastMethodFrameMessage Message
 
 	for {
-		if reader.GetParent().GetProtoIdentifier().Protocol != nil && reader.GetParent().GetProtoIdentifier().Protocol != &protocol {
+		if reader.GetProtoIdentifier().Protocol != nil && reader.GetProtoIdentifier().Protocol != &protocol {
 			return errors.New("Identified by another protocol")
 		}
 
@@ -112,12 +112,12 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 			switch lastMethodFrameMessage.(type) {
 			case *BasicPublish:
 				eventBasicPublish.Body = f.Body
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventBasicPublish, amqpRequest, basicMethodMap[40], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventBasicPublish, amqpRequest, basicMethodMap[40], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 			case *BasicDeliver:
 				eventBasicDeliver.Body = f.Body
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventBasicDeliver, amqpRequest, basicMethodMap[60], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventBasicDeliver, amqpRequest, basicMethodMap[60], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 			}
 
 		case *MethodFrame:
@@ -137,8 +137,8 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 					NoWait:     m.NoWait,
 					Arguments:  m.Arguments,
 				}
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventQueueBind, amqpRequest, queueMethodMap[20], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventQueueBind, amqpRequest, queueMethodMap[20], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 
 			case *BasicConsume:
 				eventBasicConsume := &BasicConsume{
@@ -150,8 +150,8 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 					NoWait:      m.NoWait,
 					Arguments:   m.Arguments,
 				}
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventBasicConsume, amqpRequest, basicMethodMap[20], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventBasicConsume, amqpRequest, basicMethodMap[20], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 
 			case *BasicDeliver:
 				eventBasicDeliver.ConsumerTag = m.ConsumerTag
@@ -170,8 +170,8 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 					NoWait:     m.NoWait,
 					Arguments:  m.Arguments,
 				}
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventQueueDeclare, amqpRequest, queueMethodMap[10], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventQueueDeclare, amqpRequest, queueMethodMap[10], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 
 			case *ExchangeDeclare:
 				eventExchangeDeclare := &ExchangeDeclare{
@@ -184,8 +184,8 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 					NoWait:     m.NoWait,
 					Arguments:  m.Arguments,
 				}
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventExchangeDeclare, amqpRequest, exchangeMethodMap[10], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventExchangeDeclare, amqpRequest, exchangeMethodMap[10], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 
 			case *ConnectionStart:
 				eventConnectionStart := &ConnectionStart{
@@ -195,8 +195,8 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 					Mechanisms:       m.Mechanisms,
 					Locales:          m.Locales,
 				}
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventConnectionStart, amqpRequest, connectionMethodMap[10], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventConnectionStart, amqpRequest, connectionMethodMap[10], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 
 			case *ConnectionClose:
 				eventConnectionClose := &ConnectionClose{
@@ -205,8 +205,8 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 					ClassId:   m.ClassId,
 					MethodId:  m.MethodId,
 				}
-				reader.GetParent().SetProtocol(&protocol)
-				emitAMQP(*eventConnectionClose, amqpRequest, connectionMethodMap[50], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetParent().GetOrigin())
+				reader.SetProtocol(&protocol)
+				emitAMQP(*eventConnectionClose, amqpRequest, connectionMethodMap[50], connectionInfo, reader.GetCaptureTime(), reader.GetReadProgress().Current(), reader.GetEmitter(), reader.GetOrigin())
 			}
 
 		default:

--- a/tap/extensions/amqp/tcp_reader_mock_test.go
+++ b/tap/extensions/amqp/tcp_reader_mock_test.go
@@ -78,3 +78,15 @@ func (reader *tcpReader) GetIsClosed() bool {
 func (reader *tcpReader) GetExtension() *api.Extension {
 	return reader.extension
 }
+
+func (reader *tcpReader) GetOrigin() api.Capture {
+	return reader.parent.GetOrigin()
+}
+
+func (reader *tcpReader) GetProtoIdentifier() *api.ProtoIdentifier {
+	return reader.parent.GetProtoIdentifier()
+}
+
+func (reader *tcpReader) SetProtocol(protocol *api.Protocol) {
+	reader.parent.SetProtocol(protocol)
+}

--- a/tap/extensions/amqp/tcp_reader_mock_test.go
+++ b/tap/extensions/amqp/tcp_reader_mock_test.go
@@ -15,7 +15,7 @@ type tcpReader struct {
 	isOutgoing    bool
 	progress      *api.ReadProgress
 	captureTime   time.Time
-	parent        api.TcpStream
+	parent        *tcpStream
 	extension     *api.Extension
 	emitter       api.Emitter
 	counterPair   *api.CounterPair
@@ -23,7 +23,7 @@ type tcpReader struct {
 	sync.Mutex
 }
 
-func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent api.TcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
+func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent *tcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
 	return &tcpReader{
 		progress:      progress,
 		ident:         ident,
@@ -53,10 +53,6 @@ func (reader *tcpReader) GetIsClient() bool {
 
 func (reader *tcpReader) GetReadProgress() *api.ReadProgress {
 	return reader.progress
-}
-
-func (reader *tcpReader) GetParent() api.TcpStream {
-	return reader.parent
 }
 
 func (reader *tcpReader) GetTcpID() *api.TcpID {

--- a/tap/extensions/amqp/tcp_stream_mock_test.go
+++ b/tap/extensions/amqp/tcp_stream_mock_test.go
@@ -15,7 +15,7 @@ type tcpStream struct {
 	sync.Mutex
 }
 
-func NewTcpStream(capture api.Capture) api.TcpStream {
+func NewTcpStream(capture api.Capture) *tcpStream {
 	return &tcpStream{
 		origin:          capture,
 		protoIdentifier: &api.ProtoIdentifier{},

--- a/tap/extensions/http/tcp_reader_mock_test.go
+++ b/tap/extensions/http/tcp_reader_mock_test.go
@@ -78,3 +78,15 @@ func (reader *tcpReader) GetIsClosed() bool {
 func (reader *tcpReader) GetExtension() *api.Extension {
 	return reader.extension
 }
+
+func (reader *tcpReader) GetOrigin() api.Capture {
+	return reader.parent.GetOrigin()
+}
+
+func (reader *tcpReader) GetProtoIdentifier() *api.ProtoIdentifier {
+	return reader.parent.GetProtoIdentifier()
+}
+
+func (reader *tcpReader) SetProtocol(protocol *api.Protocol) {
+	reader.parent.SetProtocol(protocol)
+}

--- a/tap/extensions/http/tcp_reader_mock_test.go
+++ b/tap/extensions/http/tcp_reader_mock_test.go
@@ -15,7 +15,7 @@ type tcpReader struct {
 	isOutgoing    bool
 	progress      *api.ReadProgress
 	captureTime   time.Time
-	parent        api.TcpStream
+	parent        *tcpStream
 	extension     *api.Extension
 	emitter       api.Emitter
 	counterPair   *api.CounterPair
@@ -23,7 +23,7 @@ type tcpReader struct {
 	sync.Mutex
 }
 
-func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent api.TcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
+func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent *tcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
 	return &tcpReader{
 		progress:      progress,
 		ident:         ident,
@@ -53,10 +53,6 @@ func (reader *tcpReader) GetIsClient() bool {
 
 func (reader *tcpReader) GetReadProgress() *api.ReadProgress {
 	return reader.progress
-}
-
-func (reader *tcpReader) GetParent() api.TcpStream {
-	return reader.parent
 }
 
 func (reader *tcpReader) GetTcpID() *api.TcpID {

--- a/tap/extensions/http/tcp_stream_mock_test.go
+++ b/tap/extensions/http/tcp_stream_mock_test.go
@@ -15,7 +15,7 @@ type tcpStream struct {
 	sync.Mutex
 }
 
-func NewTcpStream(capture api.Capture) api.TcpStream {
+func NewTcpStream(capture api.Capture) *tcpStream {
 	return &tcpStream{
 		origin:          capture,
 		protoIdentifier: &api.ProtoIdentifier{},

--- a/tap/extensions/kafka/main.go
+++ b/tap/extensions/kafka/main.go
@@ -38,7 +38,7 @@ func (d dissecting) Ping() {
 func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.TrafficFilteringOptions) error {
 	reqResMatcher := reader.GetReqResMatcher().(*requestResponseMatcher)
 	for {
-		if reader.GetParent().GetProtoIdentifier().Protocol != nil && reader.GetParent().GetProtoIdentifier().Protocol != &_protocol {
+		if reader.GetProtoIdentifier().Protocol != nil && reader.GetProtoIdentifier().Protocol != &_protocol {
 			return errors.New("Identified by another protocol")
 		}
 
@@ -47,13 +47,13 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 			if err != nil {
 				return err
 			}
-			reader.GetParent().SetProtocol(&_protocol)
+			reader.SetProtocol(&_protocol)
 		} else {
-			err := ReadResponse(b, reader.GetParent().GetOrigin(), reader.GetTcpID(), reader.GetCounterPair(), reader.GetCaptureTime(), reader.GetEmitter(), reqResMatcher)
+			err := ReadResponse(b, reader.GetOrigin(), reader.GetTcpID(), reader.GetCounterPair(), reader.GetCaptureTime(), reader.GetEmitter(), reqResMatcher)
 			if err != nil {
 				return err
 			}
-			reader.GetParent().SetProtocol(&_protocol)
+			reader.SetProtocol(&_protocol)
 		}
 	}
 }

--- a/tap/extensions/kafka/tcp_reader_mock_test.go
+++ b/tap/extensions/kafka/tcp_reader_mock_test.go
@@ -78,3 +78,15 @@ func (reader *tcpReader) GetIsClosed() bool {
 func (reader *tcpReader) GetExtension() *api.Extension {
 	return reader.extension
 }
+
+func (reader *tcpReader) GetOrigin() api.Capture {
+	return reader.parent.GetOrigin()
+}
+
+func (reader *tcpReader) GetProtoIdentifier() *api.ProtoIdentifier {
+	return reader.parent.GetProtoIdentifier()
+}
+
+func (reader *tcpReader) SetProtocol(protocol *api.Protocol) {
+	reader.parent.SetProtocol(protocol)
+}

--- a/tap/extensions/kafka/tcp_reader_mock_test.go
+++ b/tap/extensions/kafka/tcp_reader_mock_test.go
@@ -15,7 +15,7 @@ type tcpReader struct {
 	isOutgoing    bool
 	progress      *api.ReadProgress
 	captureTime   time.Time
-	parent        api.TcpStream
+	parent        *tcpStream
 	extension     *api.Extension
 	emitter       api.Emitter
 	counterPair   *api.CounterPair
@@ -23,7 +23,7 @@ type tcpReader struct {
 	sync.Mutex
 }
 
-func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent api.TcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
+func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent *tcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
 	return &tcpReader{
 		progress:      progress,
 		ident:         ident,
@@ -53,10 +53,6 @@ func (reader *tcpReader) GetIsClient() bool {
 
 func (reader *tcpReader) GetReadProgress() *api.ReadProgress {
 	return reader.progress
-}
-
-func (reader *tcpReader) GetParent() api.TcpStream {
-	return reader.parent
 }
 
 func (reader *tcpReader) GetTcpID() *api.TcpID {

--- a/tap/extensions/kafka/tcp_stream_mock_test.go
+++ b/tap/extensions/kafka/tcp_stream_mock_test.go
@@ -15,7 +15,7 @@ type tcpStream struct {
 	sync.Mutex
 }
 
-func NewTcpStream(capture api.Capture) api.TcpStream {
+func NewTcpStream(capture api.Capture) *tcpStream {
 	return &tcpStream{
 		origin:          capture,
 		protoIdentifier: &api.ProtoIdentifier{},

--- a/tap/extensions/redis/main.go
+++ b/tap/extensions/redis/main.go
@@ -48,9 +48,9 @@ func (d dissecting) Dissect(b *bufio.Reader, reader api.TcpReader, options *api.
 		}
 
 		if reader.GetIsClient() {
-			err = handleClientStream(reader.GetReadProgress(), reader.GetParent().GetOrigin(), reader.GetTcpID(), reader.GetCounterPair(), reader.GetCaptureTime(), reader.GetEmitter(), redisPacket, reqResMatcher)
+			err = handleClientStream(reader.GetReadProgress(), reader.GetOrigin(), reader.GetTcpID(), reader.GetCounterPair(), reader.GetCaptureTime(), reader.GetEmitter(), redisPacket, reqResMatcher)
 		} else {
-			err = handleServerStream(reader.GetReadProgress(), reader.GetParent().GetOrigin(), reader.GetTcpID(), reader.GetCounterPair(), reader.GetCaptureTime(), reader.GetEmitter(), redisPacket, reqResMatcher)
+			err = handleServerStream(reader.GetReadProgress(), reader.GetOrigin(), reader.GetTcpID(), reader.GetCounterPair(), reader.GetCaptureTime(), reader.GetEmitter(), redisPacket, reqResMatcher)
 		}
 
 		if err != nil {

--- a/tap/extensions/redis/tcp_reader_mock_test.go
+++ b/tap/extensions/redis/tcp_reader_mock_test.go
@@ -78,3 +78,15 @@ func (reader *tcpReader) GetIsClosed() bool {
 func (reader *tcpReader) GetExtension() *api.Extension {
 	return reader.extension
 }
+
+func (reader *tcpReader) GetOrigin() api.Capture {
+	return reader.parent.GetOrigin()
+}
+
+func (reader *tcpReader) GetProtoIdentifier() *api.ProtoIdentifier {
+	return reader.parent.GetProtoIdentifier()
+}
+
+func (reader *tcpReader) SetProtocol(protocol *api.Protocol) {
+	reader.parent.SetProtocol(protocol)
+}

--- a/tap/extensions/redis/tcp_reader_mock_test.go
+++ b/tap/extensions/redis/tcp_reader_mock_test.go
@@ -15,7 +15,7 @@ type tcpReader struct {
 	isOutgoing    bool
 	progress      *api.ReadProgress
 	captureTime   time.Time
-	parent        api.TcpStream
+	parent        *tcpStream
 	extension     *api.Extension
 	emitter       api.Emitter
 	counterPair   *api.CounterPair
@@ -23,7 +23,7 @@ type tcpReader struct {
 	sync.Mutex
 }
 
-func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent api.TcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
+func NewTcpReader(progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent *tcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
 	return &tcpReader{
 		progress:      progress,
 		ident:         ident,
@@ -53,10 +53,6 @@ func (reader *tcpReader) GetIsClient() bool {
 
 func (reader *tcpReader) GetReadProgress() *api.ReadProgress {
 	return reader.progress
-}
-
-func (reader *tcpReader) GetParent() api.TcpStream {
-	return reader.parent
 }
 
 func (reader *tcpReader) GetTcpID() *api.TcpID {

--- a/tap/extensions/redis/tcp_stream_mock_test.go
+++ b/tap/extensions/redis/tcp_stream_mock_test.go
@@ -15,7 +15,7 @@ type tcpStream struct {
 	sync.Mutex
 }
 
-func NewTcpStream(capture api.Capture) api.TcpStream {
+func NewTcpStream(capture api.Capture) *tcpStream {
 	return &tcpStream{
 		origin:          capture,
 		protoIdentifier: &api.ProtoIdentifier{},

--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -26,7 +26,7 @@ type tcpReader struct {
 	data          []byte
 	progress      *api.ReadProgress
 	captureTime   time.Time
-	parent        api.TcpStream
+	parent        *tcpStream
 	packetsSeen   uint
 	extension     *api.Extension
 	emitter       api.Emitter
@@ -35,7 +35,7 @@ type tcpReader struct {
 	sync.Mutex
 }
 
-func NewTcpReader(msgQueue chan api.TcpReaderDataMsg, progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent api.TcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
+func NewTcpReader(msgQueue chan api.TcpReaderDataMsg, progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent *tcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) *tcpReader {
 	return &tcpReader{
 		msgQueue:      msgQueue,
 		progress:      progress,
@@ -119,10 +119,6 @@ func (reader *tcpReader) GetReadProgress() *api.ReadProgress {
 	return reader.progress
 }
 
-func (reader *tcpReader) GetParent() api.TcpStream {
-	return reader.parent
-}
-
 func (reader *tcpReader) GetTcpID() *api.TcpID {
 	return reader.tcpID
 }
@@ -145,4 +141,16 @@ func (reader *tcpReader) GetIsClosed() bool {
 
 func (reader *tcpReader) GetExtension() *api.Extension {
 	return reader.extension
+}
+
+func (reader *tcpReader) GetOrigin() api.Capture {
+	return reader.parent.GetOrigin()
+}
+
+func (reader *tcpReader) GetProtoIdentifier() *api.ProtoIdentifier {
+	return reader.parent.GetProtoIdentifier()
+}
+
+func (reader *tcpReader) SetProtocol(protocol *api.Protocol) {
+	reader.parent.SetProtocol(protocol)
 }

--- a/tap/tcp_reassembly_stream.go
+++ b/tap/tcp_reassembly_stream.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers" // pulls in all layers decoders
 	"github.com/google/gopacket/reassembly"
-	"github.com/up9inc/mizu/tap/api"
 	"github.com/up9inc/mizu/tap/diagnose"
 )
 
@@ -22,10 +21,10 @@ type tcpReassemblyStream struct {
 	fsmerr     bool
 	optchecker reassembly.TCPOptionCheck
 	isDNS      bool
-	tcpStream  api.TcpStream
+	tcpStream  *tcpStream
 }
 
-func NewTcpReassemblyStream(ident string, tcp *layers.TCP, fsmOptions reassembly.TCPSimpleFSMOptions, stream api.TcpStream) ReassemblyStream {
+func NewTcpReassemblyStream(ident string, tcp *layers.TCP, fsmOptions reassembly.TCPSimpleFSMOptions, stream *tcpStream) ReassemblyStream {
 	return &tcpReassemblyStream{
 		ident:      ident,
 		tcpState:   reassembly.NewTCPSimpleFSM(fsmOptions),
@@ -145,15 +144,14 @@ func (t *tcpReassemblyStream) ReassembledSG(sg reassembly.ScatterGather, ac reas
 			// This channel is read by an tcpReader object
 			diagnose.AppStats.IncReassembledTcpPayloadsCount()
 			timestamp := ac.GetCaptureInfo().Timestamp
-			stream := t.tcpStream.(*tcpStream)
 			if dir == reassembly.TCPDirClientToServer {
-				for i := range stream.getClients() {
-					reader := stream.getClient(i).(*tcpReader)
+				for i := range t.tcpStream.getClients() {
+					reader := t.tcpStream.getClient(i).(*tcpReader)
 					reader.sendMsgIfNotClosed(NewTcpReaderDataMsg(data, timestamp))
 				}
 			} else {
-				for i := range stream.getServers() {
-					reader := stream.getServer(i).(*tcpReader)
+				for i := range t.tcpStream.getServers() {
+					reader := t.tcpStream.getServer(i).(*tcpReader)
 					reader.sendMsgIfNotClosed(NewTcpReaderDataMsg(data, timestamp))
 				}
 			}
@@ -163,7 +161,7 @@ func (t *tcpReassemblyStream) ReassembledSG(sg reassembly.ScatterGather, ac reas
 
 func (t *tcpReassemblyStream) ReassemblyComplete(ac reassembly.AssemblerContext) bool {
 	if t.tcpStream.GetIsTapTarget() && !t.tcpStream.GetIsClosed() {
-		t.tcpStream.(*tcpStream).close()
+		t.tcpStream.close()
 	}
 	// do not remove the connection to allow last ACK
 	return false

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -26,7 +26,7 @@ type tcpStream struct {
 	sync.Mutex
 }
 
-func NewTcpStream(isTapTarget bool, streamsMap api.TcpStreamMap, capture api.Capture) api.TcpStream {
+func NewTcpStream(isTapTarget bool, streamsMap api.TcpStreamMap, capture api.Capture) *tcpStream {
 	return &tcpStream{
 		isTapTarget:     isTapTarget,
 		protoIdentifier: &api.ProtoIdentifier{},

--- a/tap/tcp_stream_factory.go
+++ b/tap/tcp_stream_factory.go
@@ -61,15 +61,14 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcpLayer *lay
 	stream := NewTcpStream(isTapTarget, factory.streamsMap, getPacketOrigin(ac))
 	reassemblyStream := NewTcpReassemblyStream(fmt.Sprintf("%s:%s", net, transport), tcpLayer, fsmOptions, stream)
 	if stream.GetIsTapTarget() {
-		_stream := stream.(*tcpStream)
-		_stream.setId(factory.streamsMap.NextId())
+		stream.setId(factory.streamsMap.NextId())
 		for i, extension := range extensions {
 			reqResMatcher := extension.Dissector.NewResponseRequestMatcher()
 			counterPair := &api.CounterPair{
 				Request:  0,
 				Response: 0,
 			}
-			_stream.addClient(
+			stream.addClient(
 				NewTcpReader(
 					make(chan api.TcpReaderDataMsg),
 					&api.ReadProgress{},
@@ -90,7 +89,7 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcpLayer *lay
 					reqResMatcher,
 				),
 			)
-			_stream.addServer(
+			stream.addServer(
 				NewTcpReader(
 					make(chan api.TcpReaderDataMsg),
 					&api.ReadProgress{},
@@ -112,11 +111,11 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcpLayer *lay
 				),
 			)
 
-			factory.streamsMap.Store(stream.(*tcpStream).getId(), stream)
+			factory.streamsMap.Store(stream.getId(), stream)
 
 			factory.wg.Add(2)
-			go _stream.getClient(i).(*tcpReader).run(filteringOptions, &factory.wg)
-			go _stream.getServer(i).(*tcpReader).run(filteringOptions, &factory.wg)
+			go stream.getClient(i).(*tcpReader).run(filteringOptions, &factory.wg)
+			go stream.getServer(i).(*tcpReader).run(filteringOptions, &factory.wg)
 		}
 	}
 	return reassemblyStream

--- a/tap/tlstapper/tls_poller.go
+++ b/tap/tlstapper/tls_poller.go
@@ -158,17 +158,17 @@ func (p *tlsPoller) startNewTlsReader(chunk *tlsChunk, ip net.IP, port uint16, k
 	}
 
 	reader := &tlsReader{
-		key:         key,
-		chunks:      make(chan *tlsChunk, 1),
-		doneHandler: doneHandler,
-		progress:    &api.ReadProgress{},
-		tcpID:       &tcpid,
-		isClient:    chunk.isClient(),
-		captureTime: time.Now(),
-		parent:      p,
-		extension:   extension,
-		emitter:     tlsEmitter,
-		counterPair: &api.CounterPair{},
+		key:           key,
+		chunks:        make(chan *tlsChunk, 1),
+		doneHandler:   doneHandler,
+		progress:      &api.ReadProgress{},
+		tcpID:         &tcpid,
+		isClient:      chunk.isRequest(),
+		captureTime:   time.Now(),
+		parent:        p,
+		extension:     extension,
+		emitter:       tlsEmitter,
+		counterPair:   &api.CounterPair{},
 		reqResMatcher: p.reqResMatcher,
 	}
 

--- a/tap/tlstapper/tls_poller.go
+++ b/tap/tlstapper/tls_poller.go
@@ -131,6 +131,7 @@ func (p *tlsPoller) handleTlsChunk(chunk *tlsChunk, extension *api.Extension,
 		p.readers[key] = reader
 	}
 
+	reader.captureTime = time.Now()
 	reader.chunks <- chunk
 
 	if os.Getenv("MIZU_VERBOSE_TLS_TAPPER") == "true" {

--- a/tap/tlstapper/tls_reader.go
+++ b/tap/tlstapper/tls_reader.go
@@ -14,7 +14,6 @@ type tlsReader struct {
 	doneHandler   func(r *tlsReader)
 	progress      *api.ReadProgress
 	tcpID         *api.TcpID
-	isClosed      bool
 	isClient      bool
 	captureTime   time.Time
 	parent        api.TcpStream
@@ -22,31 +21,6 @@ type tlsReader struct {
 	emitter       api.Emitter
 	counterPair   *api.CounterPair
 	reqResMatcher api.RequestResponseMatcher
-}
-
-func NewTlsReader(key string, doneHandler func(r *tlsReader), isClient bool, stream api.TcpStream) api.TcpReader {
-	return &tlsReader{
-		key:         key,
-		chunks:      make(chan *tlsChunk, 1),
-		doneHandler: doneHandler,
-		parent:      stream,
-	}
-}
-
-func (r *tlsReader) sendChunk(chunk *tlsChunk) {
-	r.chunks <- chunk
-}
-
-func (r *tlsReader) setTcpID(tcpID *api.TcpID) {
-	r.tcpID = tcpID
-}
-
-func (r *tlsReader) setCaptureTime(captureTime time.Time) {
-	r.captureTime = captureTime
-}
-
-func (r *tlsReader) setEmitter(emitter api.Emitter) {
-	r.emitter = emitter
 }
 
 func (r *tlsReader) Read(p []byte) (int, error) {
@@ -111,7 +85,7 @@ func (r *tlsReader) GetEmitter() api.Emitter {
 }
 
 func (r *tlsReader) GetIsClosed() bool {
-	return r.isClosed
+	return false
 }
 
 func (r *tlsReader) GetExtension() *api.Extension {

--- a/tap/tlstapper/tls_reader.go
+++ b/tap/tlstapper/tls_reader.go
@@ -8,19 +8,19 @@ import (
 )
 
 type tlsReader struct {
-	key           string
-	chunks        chan *tlsChunk
-	data          []byte
-	doneHandler   func(r *tlsReader)
-	progress      *api.ReadProgress
-	tcpID         *api.TcpID
-	isClient      bool
-	captureTime   time.Time
-	parent        api.TcpStream
-	extension     *api.Extension
-	emitter       api.Emitter
-	counterPair   *api.CounterPair
-	reqResMatcher api.RequestResponseMatcher
+	key             string
+	chunks          chan *tlsChunk
+	data            []byte
+	doneHandler     func(r *tlsReader)
+	progress        *api.ReadProgress
+	tcpID           *api.TcpID
+	isClient        bool
+	captureTime     time.Time
+	extension       *api.Extension
+	emitter         api.Emitter
+	counterPair     *api.CounterPair
+	reqResMatcher   api.RequestResponseMatcher
+	protoIdentifier *api.ProtoIdentifier
 }
 
 func (r *tlsReader) Read(p []byte) (int, error) {
@@ -64,10 +64,6 @@ func (r *tlsReader) GetReadProgress() *api.ReadProgress {
 	return r.progress
 }
 
-func (r *tlsReader) GetParent() api.TcpStream {
-	return r.parent
-}
-
 func (r *tlsReader) GetTcpID() *api.TcpID {
 	return r.tcpID
 }
@@ -90,4 +86,16 @@ func (r *tlsReader) GetIsClosed() bool {
 
 func (r *tlsReader) GetExtension() *api.Extension {
 	return r.extension
+}
+
+func (r *tlsReader) GetOrigin() api.Capture {
+	return api.Ebpf
+}
+
+func (r *tlsReader) GetProtoIdentifier() *api.ProtoIdentifier {
+	return r.protoIdentifier
+}
+
+func (r *tlsReader) SetProtocol(protocol *api.Protocol) {
+	r.protoIdentifier.Protocol = protocol
 }


### PR DESCRIPTION
This PR fixes tls, which currently broken in develop.

The tls is broken because of:
1. panic because `GetReqResMatcher()` returns nil
2. tls readers remain opened because `setProtocol` does nothing
3. tls not recognized because `GetProtoIdentifier()` return nothing

Bullets 2 and 3 are because tls doesn't implement TcpStream right. And it doesn't implement it right because that in tls there is no such concept like TcpStream and TcpReader, there is only a TlsReader. The refactor tries to make TlsPoller to implement and behave like a TcpStream, but it can't. There is only a single instance of TlsPoller in the program, and there is no way to let it implement TcpStream, which is per stream.

The only reason why it had to implement TcpStream in the first place, is because the extensions do something like `reader.GetParent().XXX`. And this is wrong because:
1. It couples the extensions to pcap implementation, where it has a concept of a parent.
2. It forces tls to implement a "fake" or "dummy" TcpStream like interface.

A better solution would be to call `reader.XXX` from the extensions, the pcap implementation can delegate the method to the parent, while other implementations can do what they need to do, without the need of creating a fake class.

So the first thing the PR do, beside solving the panic, is to get rid of TcpStream, and implement `SetProtocol` and `GetProtoIdentifier` for tls in TlsReader.

---

The other thing this PR do, and it have to do it as part of this PR, is to stop using interfaces in the concrete implementation. Take a look at the function `NewTlsReader` in develop:
1. It public and there is not reason for making it public
2. It returns an interface, forcing the whole internal code to work with an interface, why?
3. Because it forces to work with interfaces, there are various casts in the code, why?

The whole concept of interface, is to be an interface across components. There is no need to use the interface in the package that create it, it just cause unnecessary casts and expose unnecessary logic to the api.

So this second thing this PR do, is to use concrete implementation internally, making the code cleaner and easier to write and read.
