### PR TITLE
Fix `panic: interface conversion: api.RequestResponseMatcher is nil, not *http.requestResponseMatcher` error

### DIFF
--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -426,7 +426,7 @@ type TcpStream interface {
 	SetProtocol(protocol *Protocol)
 	GetOrigin() Capture
 	GetProtoIdentifier() *ProtoIdentifier
-	GetReqResMatcher() RequestResponseMatcher
+	GetReqResMatchers() []RequestResponseMatcher
 	GetIsTapTarget() bool
 	GetIsClosed() bool
 }

--- a/tap/cleaner.go
+++ b/tap/cleaner.go
@@ -34,12 +34,14 @@ func (cl *Cleaner) clean() {
 	cl.assemblerMutex.Unlock()
 
 	cl.streamsMap.Range(func(k, v interface{}) bool {
-		reqResMatcher := v.(api.TcpStream).GetReqResMatcher()
-		if reqResMatcher == nil {
-			return true
+		reqResMatchers := v.(api.TcpStream).GetReqResMatchers()
+		for _, reqResMatcher := range reqResMatchers {
+			if reqResMatcher == nil {
+				continue
+			}
+			deleted := deleteOlderThan(reqResMatcher.GetMap(), startCleanTime.Add(-cl.connectionTimeout))
+			cl.stats.deleted += deleted
 		}
-		deleted := deleteOlderThan(reqResMatcher.GetMap(), startCleanTime.Add(-cl.connectionTimeout))
-		cl.stats.deleted += deleted
 		return true
 	})
 

--- a/tap/extensions/amqp/tcp_stream_mock_test.go
+++ b/tap/extensions/amqp/tcp_stream_mock_test.go
@@ -11,7 +11,7 @@ type tcpStream struct {
 	protoIdentifier *api.ProtoIdentifier
 	isTapTarget     bool
 	origin          api.Capture
-	reqResMatcher   api.RequestResponseMatcher
+	reqResMatchers  []api.RequestResponseMatcher
 	sync.Mutex
 }
 
@@ -32,8 +32,8 @@ func (t *tcpStream) GetProtoIdentifier() *api.ProtoIdentifier {
 	return t.protoIdentifier
 }
 
-func (t *tcpStream) GetReqResMatcher() api.RequestResponseMatcher {
-	return t.reqResMatcher
+func (t *tcpStream) GetReqResMatchers() []api.RequestResponseMatcher {
+	return t.reqResMatchers
 }
 
 func (t *tcpStream) GetIsTapTarget() bool {

--- a/tap/extensions/http/tcp_stream_mock_test.go
+++ b/tap/extensions/http/tcp_stream_mock_test.go
@@ -11,7 +11,7 @@ type tcpStream struct {
 	protoIdentifier *api.ProtoIdentifier
 	isTapTarget     bool
 	origin          api.Capture
-	reqResMatcher   api.RequestResponseMatcher
+	reqResMatchers  []api.RequestResponseMatcher
 	sync.Mutex
 }
 
@@ -32,8 +32,8 @@ func (t *tcpStream) GetProtoIdentifier() *api.ProtoIdentifier {
 	return t.protoIdentifier
 }
 
-func (t *tcpStream) GetReqResMatcher() api.RequestResponseMatcher {
-	return t.reqResMatcher
+func (t *tcpStream) GetReqResMatchers() []api.RequestResponseMatcher {
+	return t.reqResMatchers
 }
 
 func (t *tcpStream) GetIsTapTarget() bool {

--- a/tap/extensions/kafka/tcp_stream_mock_test.go
+++ b/tap/extensions/kafka/tcp_stream_mock_test.go
@@ -11,7 +11,7 @@ type tcpStream struct {
 	protoIdentifier *api.ProtoIdentifier
 	isTapTarget     bool
 	origin          api.Capture
-	reqResMatcher   api.RequestResponseMatcher
+	reqResMatchers  []api.RequestResponseMatcher
 	sync.Mutex
 }
 
@@ -32,8 +32,8 @@ func (t *tcpStream) GetProtoIdentifier() *api.ProtoIdentifier {
 	return t.protoIdentifier
 }
 
-func (t *tcpStream) GetReqResMatcher() api.RequestResponseMatcher {
-	return t.reqResMatcher
+func (t *tcpStream) GetReqResMatchers() []api.RequestResponseMatcher {
+	return t.reqResMatchers
 }
 
 func (t *tcpStream) GetIsTapTarget() bool {

--- a/tap/extensions/redis/tcp_stream_mock_test.go
+++ b/tap/extensions/redis/tcp_stream_mock_test.go
@@ -11,7 +11,7 @@ type tcpStream struct {
 	protoIdentifier *api.ProtoIdentifier
 	isTapTarget     bool
 	origin          api.Capture
-	reqResMatcher   api.RequestResponseMatcher
+	reqResMatchers  []api.RequestResponseMatcher
 	sync.Mutex
 }
 
@@ -32,8 +32,8 @@ func (t *tcpStream) GetProtoIdentifier() *api.ProtoIdentifier {
 	return t.protoIdentifier
 }
 
-func (t *tcpStream) GetReqResMatcher() api.RequestResponseMatcher {
-	return t.reqResMatcher
+func (t *tcpStream) GetReqResMatchers() []api.RequestResponseMatcher {
+	return t.reqResMatchers
 }
 
 func (t *tcpStream) GetIsTapTarget() bool {

--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -35,7 +35,7 @@ type tcpReader struct {
 	sync.Mutex
 }
 
-func NewTcpReader(msgQueue chan api.TcpReaderDataMsg, progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent api.TcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
+func NewTcpReader(msgQueue chan api.TcpReaderDataMsg, progress *api.ReadProgress, ident string, tcpId *api.TcpID, captureTime time.Time, parent api.TcpStream, isClient bool, isOutgoing bool, extension *api.Extension, emitter api.Emitter, counterPair *api.CounterPair, reqResMatcher api.RequestResponseMatcher) *tcpReader {
 	return &tcpReader{
 		msgQueue:      msgQueue,
 		progress:      progress,

--- a/tap/tcp_reassembly_stream.go
+++ b/tap/tcp_reassembly_stream.go
@@ -148,12 +148,12 @@ func (t *tcpReassemblyStream) ReassembledSG(sg reassembly.ScatterGather, ac reas
 			stream := t.tcpStream.(*tcpStream)
 			if dir == reassembly.TCPDirClientToServer {
 				for i := range stream.getClients() {
-					reader := stream.getClient(i).(*tcpReader)
+					reader := stream.getClient(i)
 					reader.sendMsgIfNotClosed(NewTcpReaderDataMsg(data, timestamp))
 				}
 			} else {
 				for i := range stream.getServers() {
-					reader := stream.getServer(i).(*tcpReader)
+					reader := stream.getServer(i)
 					reader.sendMsgIfNotClosed(NewTcpReaderDataMsg(data, timestamp))
 				}
 			}

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -17,8 +17,8 @@ type tcpStream struct {
 	isClosed        bool
 	protoIdentifier *api.ProtoIdentifier
 	isTapTarget     bool
-	clients         []api.TcpReader
-	servers         []api.TcpReader
+	clients         []*tcpReader
+	servers         []*tcpReader
 	origin          api.Capture
 	reqResMatchers  []api.RequestResponseMatcher
 	createdAt       time.Time
@@ -26,7 +26,7 @@ type tcpStream struct {
 	sync.Mutex
 }
 
-func NewTcpStream(isTapTarget bool, streamsMap api.TcpStreamMap, capture api.Capture) api.TcpStream {
+func NewTcpStream(isTapTarget bool, streamsMap api.TcpStreamMap, capture api.Capture) *tcpStream {
 	return &tcpStream{
 		isTapTarget:     isTapTarget,
 		protoIdentifier: &api.ProtoIdentifier{},
@@ -57,35 +57,35 @@ func (t *tcpStream) close() {
 
 	for i := range t.clients {
 		reader := t.clients[i]
-		reader.(*tcpReader).close()
+		reader.close()
 	}
 	for i := range t.servers {
 		reader := t.servers[i]
-		reader.(*tcpReader).close()
+		reader.close()
 	}
 }
 
-func (t *tcpStream) addClient(reader api.TcpReader) {
+func (t *tcpStream) addClient(reader *tcpReader) {
 	t.clients = append(t.clients, reader)
 }
 
-func (t *tcpStream) addServer(reader api.TcpReader) {
+func (t *tcpStream) addServer(reader *tcpReader) {
 	t.servers = append(t.servers, reader)
 }
 
-func (t *tcpStream) getClients() []api.TcpReader {
+func (t *tcpStream) getClients() []*tcpReader {
 	return t.clients
 }
 
-func (t *tcpStream) getServers() []api.TcpReader {
+func (t *tcpStream) getServers() []*tcpReader {
 	return t.servers
 }
 
-func (t *tcpStream) getClient(index int) api.TcpReader {
+func (t *tcpStream) getClient(index int) *tcpReader {
 	return t.clients[index]
 }
 
-func (t *tcpStream) getServer(index int) api.TcpReader {
+func (t *tcpStream) getServer(index int) *tcpReader {
 	return t.servers[index]
 }
 
@@ -106,13 +106,13 @@ func (t *tcpStream) SetProtocol(protocol *api.Protocol) {
 	for i := range t.clients {
 		reader := t.clients[i]
 		if reader.GetExtension().Protocol != t.protoIdentifier.Protocol {
-			reader.(*tcpReader).close()
+			reader.close()
 		}
 	}
 	for i := range t.servers {
 		reader := t.servers[i]
 		if reader.GetExtension().Protocol != t.protoIdentifier.Protocol {
-			reader.(*tcpReader).close()
+			reader.close()
 		}
 	}
 

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -20,7 +20,7 @@ type tcpStream struct {
 	clients         []api.TcpReader
 	servers         []api.TcpReader
 	origin          api.Capture
-	reqResMatcher   api.RequestResponseMatcher
+	reqResMatchers  []api.RequestResponseMatcher
 	createdAt       time.Time
 	streamsMap      api.TcpStreamMap
 	sync.Mutex
@@ -89,6 +89,10 @@ func (t *tcpStream) getServer(index int) api.TcpReader {
 	return t.servers[index]
 }
 
+func (t *tcpStream) addReqResMatcher(reqResMatcher api.RequestResponseMatcher) {
+	t.reqResMatchers = append(t.reqResMatchers, reqResMatcher)
+}
+
 func (t *tcpStream) SetProtocol(protocol *api.Protocol) {
 	t.Lock()
 	defer t.Unlock()
@@ -123,8 +127,8 @@ func (t *tcpStream) GetProtoIdentifier() *api.ProtoIdentifier {
 	return t.protoIdentifier
 }
 
-func (t *tcpStream) GetReqResMatcher() api.RequestResponseMatcher {
-	return t.reqResMatcher
+func (t *tcpStream) GetReqResMatchers() []api.RequestResponseMatcher {
+	return t.reqResMatchers
 }
 
 func (t *tcpStream) GetIsTapTarget() bool {

--- a/tap/tcp_stream_factory.go
+++ b/tap/tcp_stream_factory.go
@@ -65,6 +65,7 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcpLayer *lay
 		_stream.setId(factory.streamsMap.NextId())
 		for i, extension := range extensions {
 			reqResMatcher := extension.Dissector.NewResponseRequestMatcher()
+			_stream.addReqResMatcher(reqResMatcher)
 			counterPair := &api.CounterPair{
 				Request:  0,
 				Response: 0,

--- a/tap/tlstapper/tls_poller.go
+++ b/tap/tlstapper/tls_poller.go
@@ -142,6 +142,7 @@ func (p *tlsPoller) handleTlsChunk(chunk *tlsChunk, extension *api.Extension,
 		},
 		chunk.isRequest(),
 		p,
+		p.reqResMatcher,
 	)
 
 	if !exists {
@@ -292,8 +293,8 @@ func (p *tlsPoller) GetProtoIdentifier() *api.ProtoIdentifier {
 	return p.protoIdentifier
 }
 
-func (p *tlsPoller) GetReqResMatcher() api.RequestResponseMatcher {
-	return p.reqResMatcher
+func (p *tlsPoller) GetReqResMatchers() []api.RequestResponseMatcher {
+	return []api.RequestResponseMatcher{p.reqResMatcher}
 }
 
 func (p *tlsPoller) GetIsTapTarget() bool {

--- a/tap/tlstapper/tls_poller.go
+++ b/tap/tlstapper/tls_poller.go
@@ -29,11 +29,8 @@ type tlsPoller struct {
 	extension       *api.Extension
 	procfs          string
 	pidToNamespace  sync.Map
-	isClosed        bool
 	protoIdentifier *api.ProtoIdentifier
-	isTapTarget     bool
 	origin          api.Capture
-	createdAt       time.Time
 }
 
 func newTlsPoller(tls *TlsTapper, extension *api.Extension, procfs string) *tlsPoller {
@@ -46,9 +43,7 @@ func newTlsPoller(tls *TlsTapper, extension *api.Extension, procfs string) *tlsP
 		chunksReader:    nil,
 		procfs:          procfs,
 		protoIdentifier: &api.ProtoIdentifier{},
-		isTapTarget:     true,
 		origin:          api.Ebpf,
-		createdAt:       time.Now(),
 	}
 }
 
@@ -282,7 +277,7 @@ func (p *tlsPoller) logTls(chunk *tlsChunk, ip net.IP, port uint16) {
 }
 
 func (p *tlsPoller) SetProtocol(protocol *api.Protocol) {
-	// TODO: Implement
+	p.protoIdentifier.Protocol = protocol
 }
 
 func (p *tlsPoller) GetOrigin() api.Capture {
@@ -298,9 +293,9 @@ func (p *tlsPoller) GetReqResMatchers() []api.RequestResponseMatcher {
 }
 
 func (p *tlsPoller) GetIsTapTarget() bool {
-	return p.isTapTarget
+	return true
 }
 
 func (p *tlsPoller) GetIsClosed() bool {
-	return p.isClosed
+	return false
 }

--- a/tap/tlstapper/tls_reader.go
+++ b/tap/tlstapper/tls_reader.go
@@ -24,7 +24,7 @@ type tlsReader struct {
 	reqResMatcher api.RequestResponseMatcher
 }
 
-func NewTlsReader(key string, doneHandler func(r *tlsReader), isClient bool, stream api.TcpStream, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
+func NewTlsReader(key string, doneHandler func(r *tlsReader), isClient bool, stream api.TcpStream, reqResMatcher api.RequestResponseMatcher) *tlsReader {
 	return &tlsReader{
 		key:           key,
 		chunks:        make(chan *tlsChunk, 1),

--- a/tap/tlstapper/tls_reader.go
+++ b/tap/tlstapper/tls_reader.go
@@ -24,12 +24,13 @@ type tlsReader struct {
 	reqResMatcher api.RequestResponseMatcher
 }
 
-func NewTlsReader(key string, doneHandler func(r *tlsReader), isClient bool, stream api.TcpStream) api.TcpReader {
+func NewTlsReader(key string, doneHandler func(r *tlsReader), isClient bool, stream api.TcpStream, reqResMatcher api.RequestResponseMatcher) api.TcpReader {
 	return &tlsReader{
-		key:         key,
-		chunks:      make(chan *tlsChunk, 1),
-		doneHandler: doneHandler,
-		parent:      stream,
+		key:           key,
+		chunks:        make(chan *tlsChunk, 1),
+		doneHandler:   doneHandler,
+		parent:        stream,
+		reqResMatcher: reqResMatcher,
 	}
 }
 


### PR DESCRIPTION
Fixes the error below that's introduced by https://github.com/up9inc/mizu/pull/1026

```
panic: interface conversion: api.RequestResponseMatcher is nil, not *http.requestResponseMatcher

goroutine 74 [running]:
github.com/up9inc/mizu/tap/extensions/http.dissecting.Dissect({0xc0000716c0, 0xc0000716c0}, 0x44f2f2, {0x2815250, 0xc006897340}, 0xc006897301)
	/app/tap/extensions/http/main.go:90 +0xd3f
github.com/up9inc/mizu/tap/tlstapper.dissect(0xc000df4870, {0x2815250, 0xc006897340}, 0x0)
	/app/tap/tlstapper/tls_poller.go:185 +0x1a6
created by github.com/up9inc/mizu/tap/tlstapper.(*tlsPoller).startNewTlsReader
	/app/tap/tlstapper/tls_poller.go:177 +0x2ef
```

Also fixes the request-response matcher maps iteration in `clean()` method.

**No stable releases are affected.**