### PR TITLE
Remove the obsolete `replace` statements that are artifacts of a merge conflict

### DIFF
--- a/tap/api/go.mod
+++ b/tap/api/go.mod
@@ -3,7 +3,3 @@ module github.com/up9inc/mizu/tap/api
 go 1.17
 
 require github.com/google/martian v2.1.0+incompatible
-
-replace github.com/up9inc/mizu/logger v0.0.0 => ../../logger
-
-replace github.com/up9inc/mizu/shared v0.0.0 => ../../shared

--- a/tap/extensions/amqp/go.mod
+++ b/tap/extensions/amqp/go.mod
@@ -15,5 +15,3 @@ require (
 )
 
 replace github.com/up9inc/mizu/tap/api v0.0.0 => ../../api
-
-replace github.com/up9inc/mizu/logger v0.0.0 => ../../../logger

--- a/tap/extensions/http/go.mod
+++ b/tap/extensions/http/go.mod
@@ -18,5 +18,3 @@ require (
 )
 
 replace github.com/up9inc/mizu/tap/api v0.0.0 => ../../api
-
-replace github.com/up9inc/mizu/logger v0.0.0 => ../../../logger

--- a/tap/extensions/kafka/go.mod
+++ b/tap/extensions/kafka/go.mod
@@ -22,5 +22,3 @@ require (
 )
 
 replace github.com/up9inc/mizu/tap/api v0.0.0 => ../../api
-
-replace github.com/up9inc/mizu/logger v0.0.0 => ../../../logger

--- a/tap/extensions/redis/go.mod
+++ b/tap/extensions/redis/go.mod
@@ -15,5 +15,3 @@ require (
 )
 
 replace github.com/up9inc/mizu/tap/api v0.0.0 => ../../api
-
-replace github.com/up9inc/mizu/logger v0.0.0 => ../../../logger

--- a/tap/go.mod
+++ b/tap/go.mod
@@ -38,5 +38,3 @@ require (
 replace github.com/up9inc/mizu/logger v0.0.0 => ../logger
 
 replace github.com/up9inc/mizu/tap/api v0.0.0 => ./api
-
-replace github.com/up9inc/mizu/shared v0.0.0 => ../shared


### PR DESCRIPTION
Leftovers forgotten to remove, sourced from a merge conflict handled in https://github.com/up9inc/mizu/pull/1026 of changes in https://github.com/up9inc/mizu/pull/1047