### PR TITLE
Fix the Kafka `ApiKey` query and add `ApiKeyName` field (human-readable `ApiKey`)

### DIFF
--- a/tap/extensions/kafka/Makefile
+++ b/tap/extensions/kafka/Makefile
@@ -13,4 +13,4 @@ test-pull-bin:
 
 test-pull-expect:
 	@mkdir -p expect
-	@[ "${skipexpect}" ] && echo "Skipping downloading expected JSONs" || gsutil  -o 'GSUtil:parallel_process_count=5' -o 'GSUtil:parallel_thread_count=5'  -m cp -r gs://static.up9.io/mizu/test-pcap/expect8/kafka/\* expect
+	@[ "${skipexpect}" ] && echo "Skipping downloading expected JSONs" || gsutil  -o 'GSUtil:parallel_process_count=5' -o 'GSUtil:parallel_thread_count=5'  -m cp -r gs://static.up9.io/mizu/test-pcap/expect9/kafka/\* expect

--- a/tap/extensions/kafka/helpers.go
+++ b/tap/extensions/kafka/helpers.go
@@ -3,12 +3,13 @@ package kafka
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/fatih/camelcase"
 	"github.com/ohler55/ojg/jp"
@@ -37,8 +38,13 @@ type KafkaWrapper struct {
 func representRequestHeader(data map[string]interface{}, rep []interface{}) []interface{} {
 	requestHeader, _ := json.Marshal([]api.TableData{
 		{
+			Name:     "ApiKeyName",
+			Value:    data["apiKeyName"].(string),
+			Selector: `request.apiKeyName`,
+		},
+		{
 			Name:     "ApiKey",
-			Value:    apiNames[int(data["apiKey"].(float64))],
+			Value:    int(data["apiKey"].(float64)),
 			Selector: `request.apiKey`,
 		},
 		{

--- a/tap/extensions/kafka/main.go
+++ b/tap/extensions/kafka/main.go
@@ -96,8 +96,8 @@ func (d dissecting) Summarize(entry *api.Entry) *api.BaseEntry {
 	statusQuery := ""
 
 	apiKey := ApiKey(entry.Request["apiKey"].(float64))
-	method := apiNames[apiKey]
-	methodQuery := fmt.Sprintf("request.apiKey == %d", int(entry.Request["apiKey"].(float64)))
+	method := entry.Request["apiKeyName"].(string)
+	methodQuery := fmt.Sprintf(`request.apiKeyName == "%s"`, method)
 
 	summary := ""
 	summaryQuery := ""

--- a/tap/extensions/kafka/request.go
+++ b/tap/extensions/kafka/request.go
@@ -11,6 +11,7 @@ import (
 
 type Request struct {
 	Size          int32       `json:"size"`
+	ApiKeyName    string      `json:"apiKeyName"`
 	ApiKey        ApiKey      `json:"apiKey"`
 	ApiVersion    int16       `json:"apiVersion"`
 	CorrelationID int32       `json:"correlationID"`
@@ -202,6 +203,7 @@ func ReadRequest(r io.Reader, tcpID *api.TcpID, counterPair *api.CounterPair, ca
 
 	request := &Request{
 		Size:          size,
+		ApiKeyName:    apiNames[apiKey],
 		ApiKey:        apiKey,
 		ApiVersion:    apiVersion,
 		CorrelationID: correlationID,


### PR DESCRIPTION
### Before
![Screenshot from 2022-05-13 00-35-57](https://user-images.githubusercontent.com/2502080/168351076-c0a55cba-a2cf-4367-a11f-d46d7a211e1d.png)
![Screenshot from 2022-05-13 00-36-01](https://user-images.githubusercontent.com/2502080/168351136-8fe43f4d-d9c1-4438-abb6-a44267b02e70.png)
![Screenshot from 2022-05-13 00-36-04](https://user-images.githubusercontent.com/2502080/168351179-80cbfbdb-8e67-40e5-950a-70a7abf41ea4.png)

### After
![Screenshot from 2022-05-13 21-49-59](https://user-images.githubusercontent.com/2502080/168352662-b7f2cb44-827a-4923-9bfd-fcc3922b5f82.png)
![Screenshot from 2022-05-13 21-50-04](https://user-images.githubusercontent.com/2502080/168352712-aacccf92-a54a-43d5-a37e-d21caa54e2de.png)
![Screenshot from 2022-05-13 21-50-08](https://user-images.githubusercontent.com/2502080/168352777-27cc6f98-f1ee-4e20-a698-89aa14758297.png)
![Screenshot from 2022-05-13 21-50-11](https://user-images.githubusercontent.com/2502080/168352907-b4d6adb2-3ac4-482f-90ba-a8e1712bcfd0.png)

