### PR TITLE
Fix a `nil pointer dereference` error that occurs in `tcpReader`'s `Read` method

### DIFF
--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -82,10 +82,14 @@ func (reader *tcpReader) isProtocolIdentified() bool {
 }
 
 func (reader *tcpReader) rewind() {
-	// Reset the data and msgBuffer from the master record
+	// Reset the data
 	reader.data = make([]byte, 0)
+
+	// Reset msgBuffer from the master record
+	reader.parent.Lock()
 	reader.msgBuffer = make([]api.TcpReaderDataMsg, len(reader.msgBufferMaster))
 	copy(reader.msgBuffer, reader.msgBufferMaster)
+	reader.parent.Unlock()
 
 	// Reset the read progress
 	reader.progress.Reset()

--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -121,7 +121,7 @@ func (reader *tcpReader) Read(p []byte) (int, error) {
 			if !reader.isProtocolIdentified() {
 				reader.msgBufferMaster = append(
 					reader.msgBufferMaster,
-					msg,
+					NewTcpReaderDataMsg(msg.GetBytes(), msg.GetTimestamp()),
 				)
 			}
 		}

--- a/tap/tcp_reader.go
+++ b/tap/tcp_reader.go
@@ -121,7 +121,7 @@ func (reader *tcpReader) Read(p []byte) (int, error) {
 			if !reader.isProtocolIdentified() {
 				reader.msgBufferMaster = append(
 					reader.msgBufferMaster,
-					NewTcpReaderDataMsg(msg.GetBytes(), msg.GetTimestamp()),
+					msg,
 				)
 			}
 		}

--- a/tap/tcp_stream.go
+++ b/tap/tcp_stream.go
@@ -72,8 +72,10 @@ func (t *tcpStream) SetProtocol(protocol *api.Protocol) {
 	t.protocol = protocol
 
 	// Clean the buffers
+	t.Lock()
 	t.client.msgBufferMaster = make([]api.TcpReaderDataMsg, 0)
 	t.server.msgBufferMaster = make([]api.TcpReaderDataMsg, 0)
+	t.Unlock()
 }
 
 func (t *tcpStream) GetOrigin() api.Capture {


### PR DESCRIPTION
Introduced by https://github.com/up9inc/mizu/pull/1062

Causing acceptance tests failures.

**No stable releases are affected.**

Fixes the error below that occurs in case of protocols other than HTTP:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2337d67]

goroutine 57 [running]:
github.com/up9inc/mizu/tap.(*tcpReader).populateData(0xc0004be5b0, {0x0, 0x0})
	/home/mertyildiran/Documents/up9/mizu/tap/tcp_reader.go:95 +0x27
github.com/up9inc/mizu/tap.(*tcpReader).Read(0xc0004be5b0, {0xc00094c000, 0x1000, 0x7f853165ed28})
	/home/mertyildiran/Documents/up9/mizu/tap/tcp_reader.go:112 +0x3d
bufio.(*Reader).Read(0xc00048a480, {0xc00038c290, 0x7, 0xd57d07})
	/usr/local/go/src/bufio/bufio.go:227 +0x1b4
io.ReadAtLeast({0x2abb640, 0xc00048a480}, {0xc00038c290, 0x7, 0x7}, 0x7)
	/usr/local/go/src/io/io.go:328 +0x9a
io.ReadFull(...)
	/usr/local/go/src/io/io.go:347
github.com/up9inc/mizu/tap/extensions/amqp.(*AmqpReader).ReadFrame(0xc000962ad0)
	/home/mertyildiran/Documents/up9/mizu/tap/extensions/amqp/read.go:49 +0x53
github.com/up9inc/mizu/tap/extensions/amqp.dissecting.Dissect({0x0, 0xc000962ec0}, 0xd96e32, {0x2b32e08, 0xc0004be5b0}, 0x1)
	/home/mertyildiran/Documents/up9/mizu/tap/extensions/amqp/main.go:82 +0x245
github.com/up9inc/mizu/tap.(*tcpReader).run(0xc0004be5b0, 0x0, 0x0)
	/home/mertyildiran/Documents/up9/mizu/tap/tcp_reader.go:55 +0x2a4
created by github.com/up9inc/mizu/tap.(*tcpStreamFactory).New
	/home/mertyildiran/Documents/up9/mizu/tap/tcp_stream_factory.go:106 +0x162f
```