### PR TITLE
TEA_4436 - If no query selector wouldn't be tooltip to filter by hover 

### DIFF
--- a/ui-common/src/components/UI/Queryable.tsx
+++ b/ui-common/src/components/UI/Queryable.tsx
@@ -54,7 +54,7 @@ const Queryable: React.FC<Props> = ({query, style, iconStyle, className, useTool
                 {flipped && addButton}
                 {children}
                 {!flipped && addButton}
-                {useTooltip && showTooltip && <span data-cy={"QueryableTooltip"} className={QueryableStyle.QueryableTooltip} style={tooltipStyle}>{query}</span>}
+                {useTooltip && showTooltip && (query !== "") && <span data-cy={"QueryableTooltip"} className={QueryableStyle.QueryableTooltip} style={tooltipStyle}>{query}</span>}
         </div>
     );
 };


### PR DESCRIPTION
when hovering on queryable params on mizu, the filter tooltip will be shown only when there is a query selector.