### PR TITLE
Fix a `slice bounds out of range` panic in Go offsets calculation

### DIFF
--- a/tap/tlstapper/go_offsets.go
+++ b/tap/tlstapper/go_offsets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/cilium/ebpf/link"
 	"github.com/knightsc/gapstone"
+	"github.com/up9inc/mizu/logger"
 )
 
 type goOffsets struct {
@@ -145,6 +146,16 @@ func getOffsets(filePath string) (offsets map[string]*goExtendedOffset, err erro
 		symEndingIndex := symStartingIndex + sym.Size
 
 		// collect the bytes of the symbol
+		textSectionDataLen := uint64(len(textSectionData) - 1)
+		if symEndingIndex > textSectionDataLen {
+			logger.Log.Errorf(
+				"Error: Skipping symbol %v, ending index %v is bigger than text section data length %v",
+				sym.Name,
+				symEndingIndex,
+				textSectionDataLen,
+			)
+			continue
+		}
 		symBytes := textSectionData[symStartingIndex:symEndingIndex]
 
 		// disasemble the symbol

--- a/tap/tlstapper/go_offsets.go
+++ b/tap/tlstapper/go_offsets.go
@@ -148,8 +148,8 @@ func getOffsets(filePath string) (offsets map[string]*goExtendedOffset, err erro
 		// collect the bytes of the symbol
 		textSectionDataLen := uint64(len(textSectionData) - 1)
 		if symEndingIndex > textSectionDataLen {
-			logger.Log.Errorf(
-				"Error: Skipping symbol %v, ending index %v is bigger than text section data length %v",
+			logger.Log.Warningf(
+				"Skipping symbol %v, ending index %v is bigger than text section data length %v",
 				sym.Name,
 				symEndingIndex,
 				textSectionDataLen,


### PR DESCRIPTION
Introduced by https://github.com/up9inc/mizu/pull/1120