### PR TITLE
Remove Summary field from output channel item

### DIFF
--- a/tap/api/api.go
+++ b/tap/api/api.go
@@ -102,7 +102,6 @@ type OutputChannelItem struct {
 	Timestamp      int64
 	ConnectionInfo *ConnectionInfo
 	Pair           *RequestResponsePair
-	Summary        *BaseEntry
 	Namespace      string
 }
 


### PR DESCRIPTION
This fields is never populated so it is more confusing that it is here (follow up from https://github.com/up9inc/mizu/pull/1144#discussion_r901420701)