### PR TITLE
Fixed panic in socket cleanup

### DIFF
--- a/agent/pkg/api/socket_routes.go
+++ b/agent/pkg/api/socket_routes.go
@@ -97,7 +97,7 @@ func websocketHandler(c *gin.Context, eventHandlers EventHandlers, isTapper bool
 	websocketIdsLock.Unlock()
 
 	defer func() {
-		if socketConnection, ok := connectedWebsockets[socketId]; ok {
+		if socketConnection, ok := connectedWebsockets[socketId]; ok && socketConnection != nil {
 			socketCleanup(socketId, socketConnection)
 		}
 	}()

--- a/agent/pkg/api/socket_routes.go
+++ b/agent/pkg/api/socket_routes.go
@@ -97,7 +97,7 @@ func websocketHandler(c *gin.Context, eventHandlers EventHandlers, isTapper bool
 	websocketIdsLock.Unlock()
 
 	defer func() {
-		if socketConnection, ok := connectedWebsockets[socketId]; ok && socketConnection != nil {
+		if socketConnection := connectedWebsockets[socketId]; socketConnection != nil {
 			socketCleanup(socketId, socketConnection)
 		}
 	}()

--- a/agent/pkg/api/socket_routes.go
+++ b/agent/pkg/api/socket_routes.go
@@ -97,7 +97,9 @@ func websocketHandler(c *gin.Context, eventHandlers EventHandlers, isTapper bool
 	websocketIdsLock.Unlock()
 
 	defer func() {
-		socketCleanup(socketId, connectedWebsockets[socketId])
+		if socketConnection, ok := connectedWebsockets[socketId]; ok {
+			socketCleanup(socketId, socketConnection)
+		}
 	}()
 
 	eventHandlers.WebSocketConnect(c, socketId, isTapper)


### PR DESCRIPTION
```
2022/07/11 07:21:08 [Recovery] 2022/07/11 - 07:21:08 panic recovered:
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:221 (0x44f026)
/usr/local/go/src/runtime/signal_unix.go:735 (0x44eff6)
/app/agent-build/pkg/api/socket_routes.go:154 (0x1632665)
/app/agent-build/pkg/api/socket_routes.go:100 (0x163221c)
/app/agent-build/pkg/api/socket_routes.go:125 (0x163216d)
/app/agent-build/pkg/api/socket_routes.go:68 (0x1631b64)
```