### PR TITLE
Hide Response tab if there is no resepone

### DIFF
--- a/ui-common/src/components/EntryDetailed/EntryViewer/AutoRepresentation.tsx
+++ b/ui-common/src/components/EntryDetailed/EntryViewer/AutoRepresentation.tsx
@@ -32,7 +32,7 @@ export const AutoRepresentation: React.FC<any> = ({ representation, color, opene
                 badge: null
             }]
 
-        if (response) {
+        if (response && response.length > 0) {
             arr.push({
                 tab: 'Response',
                 badge: null
@@ -71,7 +71,7 @@ export const AutoRepresentation: React.FC<any> = ({ representation, color, opene
             {getOpenedTabIndex() === TabsEnum.Request && <React.Fragment>
                 <SectionsRepresentation data={request} color={color} requestRepresentation={request} />
             </React.Fragment>}
-            {response && getOpenedTabIndex() === TabsEnum.Response && <React.Fragment>
+            {response && response.length > 0 && getOpenedTabIndex() === TabsEnum.Response && <React.Fragment>
                 <SectionsRepresentation data={response} color={color} />
             </React.Fragment>}
         </div>}

--- a/ui-common/src/components/EntryDetailed/EntryViewer/SectionsRepresentation.tsx
+++ b/ui-common/src/components/EntryDetailed/EntryViewer/SectionsRepresentation.tsx
@@ -28,10 +28,6 @@ const SectionsRepresentation: React.FC<any> = ({ data, color }) => {
         }
     }
 
-    if (sections.length === 0) {
-        sections.push(<div>This request or response has no data.</div>);
-    }
-
     return <React.Fragment>{sections}</React.Fragment>;
 }
 


### PR DESCRIPTION
after merging https://github.com/up9inc/mizu/pull/1091, when there is no response we see message of "This request or response has no data", I think better solution will be to hide the response tab completely.

(in the PR we talked about remove it but the solution was to remove the request too and in this solution the Request will always be there and response will be added when exists (like it was before)

<img width="1594" alt="image" src="https://user-images.githubusercontent.com/55343099/178475813-3c593353-1f73-42b3-8a56-85d0688e623a.png">

<img width="1594" alt="image" src="https://user-images.githubusercontent.com/55343099/178475854-4ec01142-aad4-4618-be53-f3dac2d9c92d.png">
